### PR TITLE
[wip] update protos to proto3 and clean up dialyzer warnings

### DIFF
--- a/proto/hex_pb_names.proto
+++ b/proto/hex_pb_names.proto
@@ -1,4 +1,4 @@
-syntax = "proto2";
+syntax = "proto3";
 
 message Names {
   // All packages in the repository
@@ -7,7 +7,7 @@ message Names {
 
 message Package {
   // Package name
-  required string name = 1;
+  string name = 1;
   // If set, the name of the package repository
-  optional string repository = 2;
+  string repository = 2;
 }

--- a/proto/hex_pb_package.proto
+++ b/proto/hex_pb_package.proto
@@ -1,4 +1,4 @@
-syntax = "proto2";
+syntax = "proto3";
 
 message Package {
   // All releases of the package
@@ -7,19 +7,19 @@ message Package {
 
 message Release {
   // Release version
-  required string version = 1;
+  string version = 1;
   // sha256 checksum of package tarball
-  required bytes checksum = 2;
+  bytes checksum = 2;
   // All dependencies of the release
   repeated Dependency dependencies = 3;
   // If set the release is retired, a retired release should only be
   // resolved if it has already been locked in a project
-  optional RetirementStatus retired = 4;
+  RetirementStatus retired = 4;
 }
 
 message RetirementStatus {
-  required RetirementReason reason = 1;
-  optional string message = 2;
+  RetirementReason reason = 1;
+  string message = 2;
 }
 
 enum RetirementReason {
@@ -32,14 +32,14 @@ enum RetirementReason {
 
 message Dependency {
   // Package name of dependency
-  required string package = 1;
+  string package = 1;
   // Version requirement of dependency
-  required string requirement = 2;
+  string requirement = 2;
   // If set and true the package is optional (see dependency resolution)
-  optional bool optional = 3;
+  bool optional = 3;
   // If set is the OTP application name of the dependency, if not set the
   // application name is the same as the package name
-  optional string app = 4;
+  string app = 4;
   // If set, the repository where the dependency is located
-  optional string repository = 5;
+  string repository = 5;
 }

--- a/proto/hex_pb_signed.proto
+++ b/proto/hex_pb_signed.proto
@@ -1,8 +1,8 @@
-syntax = "proto2";
+syntax = "proto3";
 
 message Signed {
   // Signed contents
-  required bytes payload = 1;
+  bytes payload = 1;
   // The signature
-  optional bytes signature = 2;
+  bytes signature = 2;
 }

--- a/proto/hex_pb_versions.proto
+++ b/proto/hex_pb_versions.proto
@@ -1,4 +1,4 @@
-syntax = "proto2";
+syntax = "proto3";
 
 message Versions {
   // All packages in the repository
@@ -7,11 +7,11 @@ message Versions {
 
 message Package {
   // Package name
-  required string name = 1;
+  string name = 1;
   // All released versions of the package
   repeated string versions = 2;
   // Zero-based indexes of retired versions in the versions field, see package.proto
   repeated int32 retired = 3 [packed=true];
   // If set, the name of the package repository
-  optional string repository = 4;
+  string repository = 4;
 }

--- a/rebar.config
+++ b/rebar.config
@@ -3,12 +3,12 @@
     {i, "proto"},
     {o_erl, "src"},
     {o_hrl, "src"},
-    {verify, optionally},
+    {verify, always},
     {strings_as_binaries, true},
     {maps, true},
     {maps_unset_optional, omitted},
     {report_warnings, true},
-    {target_erlang_version, 20}            
+    {target_erlang_version, 17}
 ]}.
 {profiles, [
     {dev, [

--- a/rebar.config
+++ b/rebar.config
@@ -3,12 +3,12 @@
     {i, "proto"},
     {o_erl, "src"},
     {o_hrl, "src"},
-    {verify, always},
+    {verify, optionally},
     {strings_as_binaries, true},
     {maps, true},
     {maps_unset_optional, omitted},
     {report_warnings, true},
-    {target_erlang_version, 17}
+    {target_erlang_version, 20}            
 ]}.
 {profiles, [
     {dev, [
@@ -35,3 +35,4 @@
         {extra_src_dirs, ["test/support"]}
     ]}
 ]}.
+{xref_checks, [undefined_function_calls, undefined_functions]}.

--- a/src/hex_core.erl
+++ b/src/hex_core.erl
@@ -19,6 +19,7 @@ J1i2xWFndWa6nfFnRxZmCStCOZWYYPlaxr+FZceFbpMwzTNs4g3d4tLNUcbKAIH4
     api_url => binary(),
     api_key => binary(),
     http_adapter => module(),
+    http_adapter_config => map(),
     http_etag => binary(),
     http_user_agent_fragment => binary(),
     repo_key => binary(),

--- a/src/hex_erl_tar.hrl
+++ b/src/hex_erl_tar.hrl
@@ -43,7 +43,12 @@
 
 -type add_opt() :: dereference |
                    verbose |
-                   {chunks, pos_integer()}.
+                   {chunks, pos_integer()} |
+                   {atime, non_neg_integer()} |
+                   {mtime, non_neg_integer()} |
+                   {ctime, non_neg_integer()} |
+                   {uid, non_neg_integer()} |
+                   {gid, non_neg_integer()}.
 
 -type extract_opt() :: {cwd, string()} |
                        {files, [string()]} |

--- a/src/hex_http.erl
+++ b/src/hex_http.erl
@@ -8,14 +8,14 @@
 -type method() :: get | post | put | patch | delete.
 -type status() :: non_neg_integer().
 -type headers() :: #{binary() => binary()}.
--type body() :: nil.
+-type body() :: binary() | {string(), binary()} | nil.
 -type adapter_config() :: map().
 
 -callback request(method(), URI :: binary(), headers(), body(), adapter_config()) ->
-    {ok, status(), headers(), binary()} |
+    {ok, {status(), headers(), binary()}} |
     {error, term()}.
 
--spec request(hex_core:config(), method(), string(), headers(), body()) ->
+-spec request(hex_core:config(), method(), binary(), headers(), body()) ->
     {ok, {status(), headers(), binary()}} | {error, term()}.
 request(Config, Method, URI, Headers, Body) when is_binary(URI) and is_map(Headers) ->
     Adapter = maps:get(http_adapter, Config),

--- a/src/hex_pb_names.erl
+++ b/src/hex_pb_names.erl
@@ -32,8 +32,8 @@
       #{packages                => ['Package'()]    % = 1
        }.
 -type 'Package'() ::
-      #{name                    => iodata(),        % = 1
-        repository              => iodata()         % = 2
+      #{%% name                 => iodata()         % = 1
+        %% repository           => iodata()         % = 2
        }.
 -export_type(['Names'/0, 'Package'/0]).
 
@@ -44,10 +44,7 @@ encode_msg(Msg, MsgName) ->
 
 -spec encode_msg('Names'() | 'Package'(),'Names' | 'Package', list()) -> binary().
 encode_msg(Msg, MsgName, Opts) ->
-    case proplists:get_bool(verify, Opts) of
-      true -> verify_msg(Msg, MsgName, Opts);
-      false -> ok
-    end,
+    verify_msg(Msg, MsgName, Opts),
     TrUserData = proplists:get_value(user_data, Opts),
     case MsgName of
       'Names' -> e_msg_Names(Msg, TrUserData);
@@ -509,7 +506,6 @@ verify_msg(Msg, MsgName, Opts) ->
     end.
 
 
--dialyzer({nowarn_function,v_msg_Names/3}).
 v_msg_Names(#{} = M, Path, TrUserData) ->
     case M of
       #{packages := F1} ->
@@ -536,7 +532,6 @@ v_msg_Names(M, Path, _TrUserData) when is_map(M) ->
 v_msg_Names(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, 'Names'}, X, Path).
 
--dialyzer({nowarn_function,v_msg_Package/3}).
 v_msg_Package(#{} = M, Path, _) ->
     case M of
       #{name := F1} -> v_type_string(F1, [name | Path]);
@@ -561,7 +556,6 @@ v_msg_Package(M, Path, _TrUserData) when is_map(M) ->
 v_msg_Package(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, 'Package'}, X, Path).
 
--dialyzer({nowarn_function,v_type_string/2}).
 v_type_string(S, Path) when is_list(S); is_binary(S) ->
     try unicode:characters_to_binary(S) of
       B when is_binary(B) -> ok;
@@ -581,12 +575,11 @@ mk_type_error(Error, ValueSeen, Path) ->
 		  {Error, [{value, ValueSeen}, {path, Path2}]}}).
 
 
--dialyzer({nowarn_function,prettify_path/1}).
 prettify_path([]) -> top_level;
 prettify_path(PathR) ->
-    list_to_atom(lists:append(lists:join(".",
-					 lists:map(fun atom_to_list/1,
-						   lists:reverse(PathR))))).
+    list_to_atom(string:join(lists:map(fun atom_to_list/1,
+				       lists:reverse(PathR)),
+			     ".")).
 
 
 -compile({inline,id/2}).

--- a/src/hex_pb_package.erl
+++ b/src/hex_pb_package.erl
@@ -33,21 +33,21 @@
       #{releases                => ['Release'()]    % = 1
        }.
 -type 'Release'() ::
-      #{version                 => iodata(),        % = 1
-        checksum                => iodata(),        % = 2
-        dependencies            => ['Dependency'()], % = 3
-        retired                 => 'RetirementStatus'() % = 4
+      #{%% version              => iodata(),        % = 1
+        %% checksum             => iodata(),        % = 2
+        dependencies            => ['Dependency'()] % = 3
+        %% retired              => 'RetirementStatus'() % = 4
        }.
 -type 'RetirementStatus'() ::
-      #{reason                  => 'RETIRED_OTHER' | 'RETIRED_INVALID' | 'RETIRED_SECURITY' | 'RETIRED_DEPRECATED' | 'RETIRED_RENAMED' | integer(), % = 1, enum RetirementReason
-        message                 => iodata()         % = 2
+      #{%% reason               => 'RETIRED_OTHER' | 'RETIRED_INVALID' | 'RETIRED_SECURITY' | 'RETIRED_DEPRECATED' | 'RETIRED_RENAMED' | integer() % = 1, enum RetirementReason
+        %% message              => iodata()         % = 2
        }.
 -type 'Dependency'() ::
-      #{package                 => iodata(),        % = 1
-        requirement             => iodata(),        % = 2
-        optional                => boolean() | 0 | 1, % = 3
-        app                     => iodata(),        % = 4
-        repository              => iodata()         % = 5
+      #{%% package              => iodata()         % = 1
+        %% requirement          => iodata()         % = 2
+        %% optional             => boolean() | 0 | 1 % = 3
+        %% app                  => iodata()         % = 4
+        %% repository           => iodata()         % = 5
        }.
 -export_type(['Package'/0, 'Release'/0, 'RetirementStatus'/0, 'Dependency'/0]).
 
@@ -58,10 +58,7 @@ encode_msg(Msg, MsgName) ->
 
 -spec encode_msg('Package'() | 'Release'() | 'RetirementStatus'() | 'Dependency'(),'Package' | 'Release' | 'RetirementStatus' | 'Dependency', list()) -> binary().
 encode_msg(Msg, MsgName, Opts) ->
-    case proplists:get_bool(verify, Opts) of
-      true -> verify_msg(Msg, MsgName, Opts);
-      false -> ok
-    end,
+    verify_msg(Msg, MsgName, Opts),
     TrUserData = proplists:get_value(user_data, Opts),
     case MsgName of
       'Package' -> e_msg_Package(Msg, TrUserData);
@@ -1229,7 +1226,6 @@ verify_msg(Msg, MsgName, Opts) ->
     end.
 
 
--dialyzer({nowarn_function,v_msg_Package/3}).
 v_msg_Package(#{} = M, Path, TrUserData) ->
     case M of
       #{releases := F1} ->
@@ -1256,7 +1252,6 @@ v_msg_Package(M, Path, _TrUserData) when is_map(M) ->
 v_msg_Package(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, 'Package'}, X, Path).
 
--dialyzer({nowarn_function,v_msg_Release/3}).
 v_msg_Release(#{} = M, Path, TrUserData) ->
     case M of
       #{version := F1} -> v_type_string(F1, [version | Path]);
@@ -1302,7 +1297,6 @@ v_msg_Release(M, Path, _TrUserData) when is_map(M) ->
 v_msg_Release(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, 'Release'}, X, Path).
 
--dialyzer({nowarn_function,v_msg_RetirementStatus/3}).
 v_msg_RetirementStatus(#{} = M, Path, _) ->
     case M of
       #{reason := F1} ->
@@ -1329,7 +1323,6 @@ v_msg_RetirementStatus(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, 'RetirementStatus'}, X,
 		  Path).
 
--dialyzer({nowarn_function,v_msg_Dependency/3}).
 v_msg_Dependency(#{} = M, Path, _) ->
     case M of
       #{package := F1} -> v_type_string(F1, [package | Path]);
@@ -1370,7 +1363,6 @@ v_msg_Dependency(M, Path, _TrUserData) when is_map(M) ->
 v_msg_Dependency(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, 'Dependency'}, X, Path).
 
--dialyzer({nowarn_function,v_enum_RetirementReason/2}).
 v_enum_RetirementReason('RETIRED_OTHER', _Path) -> ok;
 v_enum_RetirementReason('RETIRED_INVALID', _Path) -> ok;
 v_enum_RetirementReason('RETIRED_SECURITY', _Path) ->
@@ -1384,7 +1376,6 @@ v_enum_RetirementReason(X, Path) ->
     mk_type_error({invalid_enum, 'RetirementReason'}, X,
 		  Path).
 
--dialyzer({nowarn_function,v_type_sint32/2}).
 v_type_sint32(N, _Path)
     when -2147483648 =< N, N =< 2147483647 ->
     ok;
@@ -1395,7 +1386,6 @@ v_type_sint32(X, Path) ->
     mk_type_error({bad_integer, sint32, signed, 32}, X,
 		  Path).
 
--dialyzer({nowarn_function,v_type_bool/2}).
 v_type_bool(false, _Path) -> ok;
 v_type_bool(true, _Path) -> ok;
 v_type_bool(0, _Path) -> ok;
@@ -1403,7 +1393,6 @@ v_type_bool(1, _Path) -> ok;
 v_type_bool(X, Path) ->
     mk_type_error(bad_boolean_value, X, Path).
 
--dialyzer({nowarn_function,v_type_string/2}).
 v_type_string(S, Path) when is_list(S); is_binary(S) ->
     try unicode:characters_to_binary(S) of
       B when is_binary(B) -> ok;
@@ -1416,7 +1405,6 @@ v_type_string(S, Path) when is_list(S); is_binary(S) ->
 v_type_string(X, Path) ->
     mk_type_error(bad_unicode_string, X, Path).
 
--dialyzer({nowarn_function,v_type_bytes/2}).
 v_type_bytes(B, _Path) when is_binary(B) -> ok;
 v_type_bytes(B, _Path) when is_list(B) -> ok;
 v_type_bytes(X, Path) ->
@@ -1429,12 +1417,11 @@ mk_type_error(Error, ValueSeen, Path) ->
 		  {Error, [{value, ValueSeen}, {path, Path2}]}}).
 
 
--dialyzer({nowarn_function,prettify_path/1}).
 prettify_path([]) -> top_level;
 prettify_path(PathR) ->
-    list_to_atom(lists:append(lists:join(".",
-					 lists:map(fun atom_to_list/1,
-						   lists:reverse(PathR))))).
+    list_to_atom(string:join(lists:map(fun atom_to_list/1,
+				       lists:reverse(PathR)),
+			     ".")).
 
 
 -compile({inline,id/2}).

--- a/src/hex_pb_package.erl
+++ b/src/hex_pb_package.erl
@@ -35,19 +35,19 @@
 -type 'Release'() ::
       #{version                 => iodata(),        % = 1
         checksum                => iodata(),        % = 2
-        dependencies            => ['Dependency'()] % = 3
-        %% retired              => 'RetirementStatus'() % = 4
+        dependencies            => ['Dependency'()], % = 3
+        retired                 => 'RetirementStatus'() % = 4
        }.
 -type 'RetirementStatus'() ::
-      #{reason                  => 'RETIRED_OTHER' | 'RETIRED_INVALID' | 'RETIRED_SECURITY' | 'RETIRED_DEPRECATED' | 'RETIRED_RENAMED' | integer() % = 1, enum RetirementReason
-        %% message              => iodata()         % = 2
+      #{reason                  => 'RETIRED_OTHER' | 'RETIRED_INVALID' | 'RETIRED_SECURITY' | 'RETIRED_DEPRECATED' | 'RETIRED_RENAMED' | integer(), % = 1, enum RetirementReason
+        message                 => iodata()         % = 2
        }.
 -type 'Dependency'() ::
       #{package                 => iodata(),        % = 1
-        requirement             => iodata()         % = 2
-        %% optional             => boolean() | 0 | 1 % = 3
-        %% app                  => iodata()         % = 4
-        %% repository           => iodata()         % = 5
+        requirement             => iodata(),        % = 2
+        optional                => boolean() | 0 | 1, % = 3
+        app                     => iodata(),        % = 4
+        repository              => iodata()         % = 5
        }.
 -export_type(['Package'/0, 'Release'/0, 'RetirementStatus'/0, 'Dependency'/0]).
 
@@ -58,7 +58,10 @@ encode_msg(Msg, MsgName) ->
 
 -spec encode_msg('Package'() | 'Release'() | 'RetirementStatus'() | 'Dependency'(),'Package' | 'Release' | 'RetirementStatus' | 'Dependency', list()) -> binary().
 encode_msg(Msg, MsgName, Opts) ->
-    verify_msg(Msg, MsgName, Opts),
+    case proplists:get_bool(verify, Opts) of
+      true -> verify_msg(Msg, MsgName, Opts);
+      false -> ok
+    end,
     TrUserData = proplists:get_value(user_data, Opts),
     case MsgName of
       'Package' -> e_msg_Package(Msg, TrUserData);
@@ -88,15 +91,28 @@ e_msg_Release(Msg, TrUserData) ->
     e_msg_Release(Msg, <<>>, TrUserData).
 
 
-e_msg_Release(#{version := F1, checksum := F2} = M, Bin,
-	      TrUserData) ->
-    B1 = begin
-	   TrF1 = id(F1, TrUserData),
-	   e_type_string(TrF1, <<Bin/binary, 10>>)
+e_msg_Release(#{} = M, Bin, TrUserData) ->
+    B1 = case M of
+	   #{version := F1} ->
+	       begin
+		 TrF1 = id(F1, TrUserData),
+		 case is_empty_string(TrF1) of
+		   true -> Bin;
+		   false -> e_type_string(TrF1, <<Bin/binary, 10>>)
+		 end
+	       end;
+	   _ -> Bin
 	 end,
-    B2 = begin
-	   TrF2 = id(F2, TrUserData),
-	   e_type_bytes(TrF2, <<B1/binary, 18>>)
+    B2 = case M of
+	   #{checksum := F2} ->
+	       begin
+		 TrF2 = id(F2, TrUserData),
+		 case iolist_size(TrF2) of
+		   0 -> B1;
+		   _ -> e_type_bytes(TrF2, <<B1/binary, 18>>)
+		 end
+	       end;
+	   _ -> B1
 	 end,
     B3 = case M of
 	   #{dependencies := F3} ->
@@ -111,8 +127,11 @@ e_msg_Release(#{version := F1, checksum := F2} = M, Bin,
       #{retired := F4} ->
 	  begin
 	    TrF4 = id(F4, TrUserData),
-	    e_mfield_Release_retired(TrF4, <<B3/binary, 34>>,
-				     TrUserData)
+	    if TrF4 =:= undefined -> B3;
+	       true ->
+		   e_mfield_Release_retired(TrF4, <<B3/binary, 34>>,
+					    TrUserData)
+	    end
 	  end;
       _ -> B3
     end.
@@ -121,17 +140,25 @@ e_msg_RetirementStatus(Msg, TrUserData) ->
     e_msg_RetirementStatus(Msg, <<>>, TrUserData).
 
 
-e_msg_RetirementStatus(#{reason := F1} = M, Bin,
-		       TrUserData) ->
-    B1 = begin
-	   TrF1 = id(F1, TrUserData),
-	   e_enum_RetirementReason(TrF1, <<Bin/binary, 8>>)
+e_msg_RetirementStatus(#{} = M, Bin, TrUserData) ->
+    B1 = case M of
+	   #{reason := F1} ->
+	       begin
+		 TrF1 = id(F1, TrUserData),
+		 if TrF1 =:= 'RETIRED_OTHER'; TrF1 =:= 0 -> Bin;
+		    true -> e_enum_RetirementReason(TrF1, <<Bin/binary, 8>>)
+		 end
+	       end;
+	   _ -> Bin
 	 end,
     case M of
       #{message := F2} ->
 	  begin
 	    TrF2 = id(F2, TrUserData),
-	    e_type_string(TrF2, <<B1/binary, 18>>)
+	    case is_empty_string(TrF2) of
+	      true -> B1;
+	      false -> e_type_string(TrF2, <<B1/binary, 18>>)
+	    end
 	  end;
       _ -> B1
     end.
@@ -140,22 +167,36 @@ e_msg_Dependency(Msg, TrUserData) ->
     e_msg_Dependency(Msg, <<>>, TrUserData).
 
 
-e_msg_Dependency(#{package := F1, requirement := F2} =
-		     M,
-		 Bin, TrUserData) ->
-    B1 = begin
-	   TrF1 = id(F1, TrUserData),
-	   e_type_string(TrF1, <<Bin/binary, 10>>)
+e_msg_Dependency(#{} = M, Bin, TrUserData) ->
+    B1 = case M of
+	   #{package := F1} ->
+	       begin
+		 TrF1 = id(F1, TrUserData),
+		 case is_empty_string(TrF1) of
+		   true -> Bin;
+		   false -> e_type_string(TrF1, <<Bin/binary, 10>>)
+		 end
+	       end;
+	   _ -> Bin
 	 end,
-    B2 = begin
-	   TrF2 = id(F2, TrUserData),
-	   e_type_string(TrF2, <<B1/binary, 18>>)
+    B2 = case M of
+	   #{requirement := F2} ->
+	       begin
+		 TrF2 = id(F2, TrUserData),
+		 case is_empty_string(TrF2) of
+		   true -> B1;
+		   false -> e_type_string(TrF2, <<B1/binary, 18>>)
+		 end
+	       end;
+	   _ -> B1
 	 end,
     B3 = case M of
 	   #{optional := F3} ->
 	       begin
 		 TrF3 = id(F3, TrUserData),
-		 e_type_bool(TrF3, <<B2/binary, 24>>)
+		 if TrF3 =:= false -> B2;
+		    true -> e_type_bool(TrF3, <<B2/binary, 24>>)
+		 end
 	       end;
 	   _ -> B2
 	 end,
@@ -163,7 +204,10 @@ e_msg_Dependency(#{package := F1, requirement := F2} =
 	   #{app := F4} ->
 	       begin
 		 TrF4 = id(F4, TrUserData),
-		 e_type_string(TrF4, <<B3/binary, 34>>)
+		 case is_empty_string(TrF4) of
+		   true -> B3;
+		   false -> e_type_string(TrF4, <<B3/binary, 34>>)
+		 end
 	       end;
 	   _ -> B3
 	 end,
@@ -171,7 +215,10 @@ e_msg_Dependency(#{package := F1, requirement := F2} =
       #{repository := F5} ->
 	  begin
 	    TrF5 = id(F5, TrUserData),
-	    e_type_string(TrF5, <<B4/binary, 42>>)
+	    case is_empty_string(TrF5) of
+	      true -> B4;
+	      false -> e_type_string(TrF5, <<B4/binary, 42>>)
+	    end
 	  end;
       _ -> B4
     end.
@@ -243,6 +290,25 @@ e_varint(N, Bin) when N =< 127 -> <<Bin/binary, N>>;
 e_varint(N, Bin) ->
     Bin2 = <<Bin/binary, (N band 127 bor 128)>>,
     e_varint(N bsr 7, Bin2).
+
+is_empty_string("") -> true;
+is_empty_string(<<>>) -> true;
+is_empty_string(L) when is_list(L) ->
+    not string_has_chars(L);
+is_empty_string(B) when is_binary(B) -> false.
+
+string_has_chars([C | _]) when is_integer(C) -> true;
+string_has_chars([H | T]) ->
+    case string_has_chars(H) of
+      true -> true;
+      false -> string_has_chars(T)
+    end;
+string_has_chars(B)
+    when is_binary(B), byte_size(B) =/= 0 ->
+    true;
+string_has_chars(C) when is_integer(C) -> true;
+string_has_chars(<<>>) -> false;
+string_has_chars([]) -> false.
 
 
 decode_msg(Bin, MsgName) when is_binary(Bin) ->
@@ -382,9 +448,9 @@ skip_64_Package(<<_:64, Rest/binary>>, Z1, Z2, F@_1,
 
 d_msg_Release(Bin, TrUserData) ->
     dfp_read_field_def_Release(Bin, 0, 0,
-			       id('$undef', TrUserData),
-			       id('$undef', TrUserData), id([], TrUserData),
-			       id('$undef', TrUserData), TrUserData).
+			       id(<<>>, TrUserData), id(<<>>, TrUserData),
+			       id([], TrUserData), id(undefined, TrUserData),
+			       TrUserData).
 
 dfp_read_field_def_Release(<<10, Rest/binary>>, Z1, Z2,
 			   F@_1, F@_2, F@_3, F@_4, TrUserData) ->
@@ -404,10 +470,15 @@ dfp_read_field_def_Release(<<34, Rest/binary>>, Z1, Z2,
 			    F@_4, TrUserData);
 dfp_read_field_def_Release(<<>>, 0, 0, F@_1, F@_2, R1,
 			   F@_4, TrUserData) ->
-    S1 = #{version => F@_1, checksum => F@_2,
-	   dependencies => lists_reverse(R1, TrUserData)},
-    if F@_4 == '$undef' -> S1;
-       true -> S1#{retired => F@_4}
+    S1 = #{dependencies => lists_reverse(R1, TrUserData)},
+    S2 = if F@_1 == '$undef' -> S1;
+	    true -> S1#{version => F@_1}
+	 end,
+    S3 = if F@_2 == '$undef' -> S2;
+	    true -> S2#{checksum => F@_2}
+	 end,
+    if F@_4 == '$undef' -> S3;
+       true -> S3#{retired => F@_4}
     end;
 dfp_read_field_def_Release(Other, Z1, Z2, F@_1, F@_2,
 			   F@_3, F@_4, TrUserData) ->
@@ -456,10 +527,15 @@ dg_read_field_def_Release(<<0:1, X:7, Rest/binary>>, N,
     end;
 dg_read_field_def_Release(<<>>, 0, 0, F@_1, F@_2, R1,
 			  F@_4, TrUserData) ->
-    S1 = #{version => F@_1, checksum => F@_2,
-	   dependencies => lists_reverse(R1, TrUserData)},
-    if F@_4 == '$undef' -> S1;
-       true -> S1#{retired => F@_4}
+    S1 = #{dependencies => lists_reverse(R1, TrUserData)},
+    S2 = if F@_1 == '$undef' -> S1;
+	    true -> S1#{version => F@_1}
+	 end,
+    S3 = if F@_2 == '$undef' -> S2;
+	    true -> S2#{checksum => F@_2}
+	 end,
+    if F@_4 == '$undef' -> S3;
+       true -> S3#{retired => F@_4}
     end.
 
 d_field_Release_version(<<1:1, X:7, Rest/binary>>, N,
@@ -573,8 +649,8 @@ skip_64_Release(<<_:64, Rest/binary>>, Z1, Z2, F@_1,
 
 d_msg_RetirementStatus(Bin, TrUserData) ->
     dfp_read_field_def_RetirementStatus(Bin, 0, 0,
-					id('$undef', TrUserData),
-					id('$undef', TrUserData), TrUserData).
+					id('RETIRED_OTHER', TrUserData),
+					id(<<>>, TrUserData), TrUserData).
 
 dfp_read_field_def_RetirementStatus(<<8, Rest/binary>>,
 				    Z1, Z2, F@_1, F@_2, TrUserData) ->
@@ -586,9 +662,12 @@ dfp_read_field_def_RetirementStatus(<<18, Rest/binary>>,
 				     F@_2, TrUserData);
 dfp_read_field_def_RetirementStatus(<<>>, 0, 0, F@_1,
 				    F@_2, _) ->
-    S1 = #{reason => F@_1},
-    if F@_2 == '$undef' -> S1;
-       true -> S1#{message => F@_2}
+    S1 = #{},
+    S2 = if F@_1 == '$undef' -> S1;
+	    true -> S1#{reason => F@_1}
+	 end,
+    if F@_2 == '$undef' -> S2;
+       true -> S2#{message => F@_2}
     end;
 dfp_read_field_def_RetirementStatus(Other, Z1, Z2, F@_1,
 				    F@_2, TrUserData) ->
@@ -633,9 +712,12 @@ dg_read_field_def_RetirementStatus(<<0:1, X:7,
     end;
 dg_read_field_def_RetirementStatus(<<>>, 0, 0, F@_1,
 				   F@_2, _) ->
-    S1 = #{reason => F@_1},
-    if F@_2 == '$undef' -> S1;
-       true -> S1#{message => F@_2}
+    S1 = #{},
+    S2 = if F@_1 == '$undef' -> S1;
+	    true -> S1#{reason => F@_1}
+	 end,
+    if F@_2 == '$undef' -> S2;
+       true -> S2#{message => F@_2}
     end.
 
 d_field_RetirementStatus_reason(<<1:1, X:7,
@@ -716,11 +798,9 @@ skip_64_RetirementStatus(<<_:64, Rest/binary>>, Z1, Z2,
 
 d_msg_Dependency(Bin, TrUserData) ->
     dfp_read_field_def_Dependency(Bin, 0, 0,
-				  id('$undef', TrUserData),
-				  id('$undef', TrUserData),
-				  id('$undef', TrUserData),
-				  id('$undef', TrUserData),
-				  id('$undef', TrUserData), TrUserData).
+				  id(<<>>, TrUserData), id(<<>>, TrUserData),
+				  id(false, TrUserData), id(<<>>, TrUserData),
+				  id(<<>>, TrUserData), TrUserData).
 
 dfp_read_field_def_Dependency(<<10, Rest/binary>>, Z1,
 			      Z2, F@_1, F@_2, F@_3, F@_4, F@_5, TrUserData) ->
@@ -744,15 +824,21 @@ dfp_read_field_def_Dependency(<<42, Rest/binary>>, Z1,
 				  F@_3, F@_4, F@_5, TrUserData);
 dfp_read_field_def_Dependency(<<>>, 0, 0, F@_1, F@_2,
 			      F@_3, F@_4, F@_5, _) ->
-    S1 = #{package => F@_1, requirement => F@_2},
-    S2 = if F@_3 == '$undef' -> S1;
-	    true -> S1#{optional => F@_3}
+    S1 = #{},
+    S2 = if F@_1 == '$undef' -> S1;
+	    true -> S1#{package => F@_1}
 	 end,
-    S3 = if F@_4 == '$undef' -> S2;
-	    true -> S2#{app => F@_4}
+    S3 = if F@_2 == '$undef' -> S2;
+	    true -> S2#{requirement => F@_2}
 	 end,
-    if F@_5 == '$undef' -> S3;
-       true -> S3#{repository => F@_5}
+    S4 = if F@_3 == '$undef' -> S3;
+	    true -> S3#{optional => F@_3}
+	 end,
+    S5 = if F@_4 == '$undef' -> S4;
+	    true -> S4#{app => F@_4}
+	 end,
+    if F@_5 == '$undef' -> S5;
+       true -> S5#{repository => F@_5}
     end;
 dfp_read_field_def_Dependency(Other, Z1, Z2, F@_1, F@_2,
 			      F@_3, F@_4, F@_5, TrUserData) ->
@@ -805,15 +891,21 @@ dg_read_field_def_Dependency(<<0:1, X:7, Rest/binary>>,
     end;
 dg_read_field_def_Dependency(<<>>, 0, 0, F@_1, F@_2,
 			     F@_3, F@_4, F@_5, _) ->
-    S1 = #{package => F@_1, requirement => F@_2},
-    S2 = if F@_3 == '$undef' -> S1;
-	    true -> S1#{optional => F@_3}
+    S1 = #{},
+    S2 = if F@_1 == '$undef' -> S1;
+	    true -> S1#{package => F@_1}
 	 end,
-    S3 = if F@_4 == '$undef' -> S2;
-	    true -> S2#{app => F@_4}
+    S3 = if F@_2 == '$undef' -> S2;
+	    true -> S2#{requirement => F@_2}
 	 end,
-    if F@_5 == '$undef' -> S3;
-       true -> S3#{repository => F@_5}
+    S4 = if F@_3 == '$undef' -> S3;
+	    true -> S3#{optional => F@_3}
+	 end,
+    S5 = if F@_4 == '$undef' -> S4;
+	    true -> S4#{app => F@_4}
+	 end,
+    if F@_5 == '$undef' -> S5;
+       true -> S5#{repository => F@_5}
     end.
 
 d_field_Dependency_package(<<1:1, X:7, Rest/binary>>, N,
@@ -1026,69 +1118,95 @@ merge_msg_Package(PMsg, NMsg, TrUserData) ->
       {_, _} -> S1
     end.
 
-merge_msg_Release(#{} = PMsg,
-		  #{version := NFversion, checksum := NFchecksum} = NMsg,
-		  TrUserData) ->
-    S1 = #{version => NFversion, checksum => NFchecksum},
+merge_msg_Release(PMsg, NMsg, TrUserData) ->
+    S1 = #{},
     S2 = case {PMsg, NMsg} of
-	   {#{dependencies := PFdependencies},
-	    #{dependencies := NFdependencies}} ->
-	       S1#{dependencies =>
-		       'erlang_++'(PFdependencies, NFdependencies,
-				   TrUserData)};
-	   {_, #{dependencies := NFdependencies}} ->
-	       S1#{dependencies => NFdependencies};
-	   {#{dependencies := PFdependencies}, _} ->
-	       S1#{dependencies => PFdependencies};
-	   {_, _} -> S1
-	 end,
-    case {PMsg, NMsg} of
-      {#{retired := PFretired}, #{retired := NFretired}} ->
-	  S2#{retired =>
-		  merge_msg_RetirementStatus(PFretired, NFretired,
-					     TrUserData)};
-      {_, #{retired := NFretired}} ->
-	  S2#{retired => NFretired};
-      {#{retired := PFretired}, _} ->
-	  S2#{retired => PFretired};
-      {_, _} -> S2
-    end.
-
-merge_msg_RetirementStatus(#{} = PMsg,
-			   #{reason := NFreason} = NMsg, _) ->
-    S1 = #{reason => NFreason},
-    case {PMsg, NMsg} of
-      {_, #{message := NFmessage}} ->
-	  S1#{message => NFmessage};
-      {#{message := PFmessage}, _} ->
-	  S1#{message => PFmessage};
-      _ -> S1
-    end.
-
-merge_msg_Dependency(#{} = PMsg,
-		     #{package := NFpackage, requirement := NFrequirement} =
-			 NMsg,
-		     _) ->
-    S1 = #{package => NFpackage,
-	   requirement => NFrequirement},
-    S2 = case {PMsg, NMsg} of
-	   {_, #{optional := NFoptional}} ->
-	       S1#{optional => NFoptional};
-	   {#{optional := PFoptional}, _} ->
-	       S1#{optional => PFoptional};
+	   {_, #{version := NFversion}} ->
+	       S1#{version => NFversion};
+	   {#{version := PFversion}, _} ->
+	       S1#{version => PFversion};
 	   _ -> S1
 	 end,
     S3 = case {PMsg, NMsg} of
-	   {_, #{app := NFapp}} -> S2#{app => NFapp};
-	   {#{app := PFapp}, _} -> S2#{app => PFapp};
+	   {_, #{checksum := NFchecksum}} ->
+	       S2#{checksum => NFchecksum};
+	   {#{checksum := PFchecksum}, _} ->
+	       S2#{checksum => PFchecksum};
 	   _ -> S2
+	 end,
+    S4 = case {PMsg, NMsg} of
+	   {#{dependencies := PFdependencies},
+	    #{dependencies := NFdependencies}} ->
+	       S3#{dependencies =>
+		       'erlang_++'(PFdependencies, NFdependencies,
+				   TrUserData)};
+	   {_, #{dependencies := NFdependencies}} ->
+	       S3#{dependencies => NFdependencies};
+	   {#{dependencies := PFdependencies}, _} ->
+	       S3#{dependencies => PFdependencies};
+	   {_, _} -> S3
+	 end,
+    case {PMsg, NMsg} of
+      {#{retired := PFretired}, #{retired := NFretired}} ->
+	  S4#{retired =>
+		  merge_msg_RetirementStatus(PFretired, NFretired,
+					     TrUserData)};
+      {_, #{retired := NFretired}} ->
+	  S4#{retired => NFretired};
+      {#{retired := PFretired}, _} ->
+	  S4#{retired => PFretired};
+      {_, _} -> S4
+    end.
+
+merge_msg_RetirementStatus(PMsg, NMsg, _) ->
+    S1 = #{},
+    S2 = case {PMsg, NMsg} of
+	   {_, #{reason := NFreason}} -> S1#{reason => NFreason};
+	   {#{reason := PFreason}, _} -> S1#{reason => PFreason};
+	   _ -> S1
+	 end,
+    case {PMsg, NMsg} of
+      {_, #{message := NFmessage}} ->
+	  S2#{message => NFmessage};
+      {#{message := PFmessage}, _} ->
+	  S2#{message => PFmessage};
+      _ -> S2
+    end.
+
+merge_msg_Dependency(PMsg, NMsg, _) ->
+    S1 = #{},
+    S2 = case {PMsg, NMsg} of
+	   {_, #{package := NFpackage}} ->
+	       S1#{package => NFpackage};
+	   {#{package := PFpackage}, _} ->
+	       S1#{package => PFpackage};
+	   _ -> S1
+	 end,
+    S3 = case {PMsg, NMsg} of
+	   {_, #{requirement := NFrequirement}} ->
+	       S2#{requirement => NFrequirement};
+	   {#{requirement := PFrequirement}, _} ->
+	       S2#{requirement => PFrequirement};
+	   _ -> S2
+	 end,
+    S4 = case {PMsg, NMsg} of
+	   {_, #{optional := NFoptional}} ->
+	       S3#{optional => NFoptional};
+	   {#{optional := PFoptional}, _} ->
+	       S3#{optional => PFoptional};
+	   _ -> S3
+	 end,
+    S5 = case {PMsg, NMsg} of
+	   {_, #{app := NFapp}} -> S4#{app => NFapp};
+	   {#{app := PFapp}, _} -> S4#{app => PFapp};
+	   _ -> S4
 	 end,
     case {PMsg, NMsg} of
       {_, #{repository := NFrepository}} ->
-	  S3#{repository => NFrepository};
+	  S5#{repository => NFrepository};
       {#{repository := PFrepository}, _} ->
-	  S3#{repository => PFrepository};
-      _ -> S3
+	  S5#{repository => PFrepository};
+      _ -> S5
     end.
 
 
@@ -1111,6 +1229,7 @@ verify_msg(Msg, MsgName, Opts) ->
     end.
 
 
+-dialyzer({nowarn_function,v_msg_Package/3}).
 v_msg_Package(#{} = M, Path, TrUserData) ->
     case M of
       #{releases := F1} ->
@@ -1137,10 +1256,17 @@ v_msg_Package(M, Path, _TrUserData) when is_map(M) ->
 v_msg_Package(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, 'Package'}, X, Path).
 
-v_msg_Release(#{version := F1, checksum := F2} = M,
-	      Path, TrUserData) ->
-    v_type_string(F1, [version | Path]),
-    v_type_bytes(F2, [checksum | Path]),
+-dialyzer({nowarn_function,v_msg_Release/3}).
+v_msg_Release(#{} = M, Path, TrUserData) ->
+    case M of
+      #{version := F1} -> v_type_string(F1, [version | Path]);
+      _ -> ok
+    end,
+    case M of
+      #{checksum := F2} ->
+	  v_type_bytes(F2, [checksum | Path]);
+      _ -> ok
+    end,
     case M of
       #{dependencies := F3} ->
 	  if is_list(F3) ->
@@ -1170,14 +1296,19 @@ v_msg_Release(#{version := F1, checksum := F2} = M,
 		  maps:keys(M)),
     ok;
 v_msg_Release(M, Path, _TrUserData) when is_map(M) ->
-    mk_type_error({missing_fields,
-		   [version, checksum] -- maps:keys(M), 'Release'},
+    mk_type_error({missing_fields, [] -- maps:keys(M),
+		   'Release'},
 		  M, Path);
 v_msg_Release(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, 'Release'}, X, Path).
 
-v_msg_RetirementStatus(#{reason := F1} = M, Path, _) ->
-    v_enum_RetirementReason(F1, [reason | Path]),
+-dialyzer({nowarn_function,v_msg_RetirementStatus/3}).
+v_msg_RetirementStatus(#{} = M, Path, _) ->
+    case M of
+      #{reason := F1} ->
+	  v_enum_RetirementReason(F1, [reason | Path]);
+      _ -> ok
+    end,
     case M of
       #{message := F2} -> v_type_string(F2, [message | Path]);
       _ -> ok
@@ -1191,18 +1322,24 @@ v_msg_RetirementStatus(#{reason := F1} = M, Path, _) ->
     ok;
 v_msg_RetirementStatus(M, Path, _TrUserData)
     when is_map(M) ->
-    mk_type_error({missing_fields, [reason] -- maps:keys(M),
+    mk_type_error({missing_fields, [] -- maps:keys(M),
 		   'RetirementStatus'},
 		  M, Path);
 v_msg_RetirementStatus(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, 'RetirementStatus'}, X,
 		  Path).
 
-v_msg_Dependency(#{package := F1, requirement := F2} =
-		     M,
-		 Path, _) ->
-    v_type_string(F1, [package | Path]),
-    v_type_string(F2, [requirement | Path]),
+-dialyzer({nowarn_function,v_msg_Dependency/3}).
+v_msg_Dependency(#{} = M, Path, _) ->
+    case M of
+      #{package := F1} -> v_type_string(F1, [package | Path]);
+      _ -> ok
+    end,
+    case M of
+      #{requirement := F2} ->
+	  v_type_string(F2, [requirement | Path]);
+      _ -> ok
+    end,
     case M of
       #{optional := F3} -> v_type_bool(F3, [optional | Path]);
       _ -> ok
@@ -1227,12 +1364,13 @@ v_msg_Dependency(#{package := F1, requirement := F2} =
 		  maps:keys(M)),
     ok;
 v_msg_Dependency(M, Path, _TrUserData) when is_map(M) ->
-    mk_type_error({missing_fields,
-		   [package, requirement] -- maps:keys(M), 'Dependency'},
+    mk_type_error({missing_fields, [] -- maps:keys(M),
+		   'Dependency'},
 		  M, Path);
 v_msg_Dependency(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, 'Dependency'}, X, Path).
 
+-dialyzer({nowarn_function,v_enum_RetirementReason/2}).
 v_enum_RetirementReason('RETIRED_OTHER', _Path) -> ok;
 v_enum_RetirementReason('RETIRED_INVALID', _Path) -> ok;
 v_enum_RetirementReason('RETIRED_SECURITY', _Path) ->
@@ -1246,6 +1384,7 @@ v_enum_RetirementReason(X, Path) ->
     mk_type_error({invalid_enum, 'RetirementReason'}, X,
 		  Path).
 
+-dialyzer({nowarn_function,v_type_sint32/2}).
 v_type_sint32(N, _Path)
     when -2147483648 =< N, N =< 2147483647 ->
     ok;
@@ -1256,6 +1395,7 @@ v_type_sint32(X, Path) ->
     mk_type_error({bad_integer, sint32, signed, 32}, X,
 		  Path).
 
+-dialyzer({nowarn_function,v_type_bool/2}).
 v_type_bool(false, _Path) -> ok;
 v_type_bool(true, _Path) -> ok;
 v_type_bool(0, _Path) -> ok;
@@ -1263,6 +1403,7 @@ v_type_bool(1, _Path) -> ok;
 v_type_bool(X, Path) ->
     mk_type_error(bad_boolean_value, X, Path).
 
+-dialyzer({nowarn_function,v_type_string/2}).
 v_type_string(S, Path) when is_list(S); is_binary(S) ->
     try unicode:characters_to_binary(S) of
       B when is_binary(B) -> ok;
@@ -1275,6 +1416,7 @@ v_type_string(S, Path) when is_list(S); is_binary(S) ->
 v_type_string(X, Path) ->
     mk_type_error(bad_unicode_string, X, Path).
 
+-dialyzer({nowarn_function,v_type_bytes/2}).
 v_type_bytes(B, _Path) when is_binary(B) -> ok;
 v_type_bytes(B, _Path) when is_list(B) -> ok;
 v_type_bytes(X, Path) ->
@@ -1287,11 +1429,12 @@ mk_type_error(Error, ValueSeen, Path) ->
 		  {Error, [{value, ValueSeen}, {path, Path2}]}}).
 
 
+-dialyzer({nowarn_function,prettify_path/1}).
 prettify_path([]) -> top_level;
 prettify_path(PathR) ->
-    list_to_atom(string:join(lists:map(fun atom_to_list/1,
-				       lists:reverse(PathR)),
-			     ".")).
+    list_to_atom(lists:append(lists:join(".",
+					 lists:map(fun atom_to_list/1,
+						   lists:reverse(PathR))))).
 
 
 -compile({inline,id/2}).
@@ -1316,9 +1459,9 @@ get_msg_defs() ->
 	 opts => []}]},
      {{msg, 'Release'},
       [#{name => version, fnum => 1, rnum => 2,
-	 type => string, occurrence => required, opts => []},
+	 type => string, occurrence => optional, opts => []},
        #{name => checksum, fnum => 2, rnum => 3, type => bytes,
-	 occurrence => required, opts => []},
+	 occurrence => optional, opts => []},
        #{name => dependencies, fnum => 3, rnum => 4,
 	 type => {msg, 'Dependency'}, occurrence => repeated,
 	 opts => []},
@@ -1328,14 +1471,14 @@ get_msg_defs() ->
      {{msg, 'RetirementStatus'},
       [#{name => reason, fnum => 1, rnum => 2,
 	 type => {enum, 'RetirementReason'},
-	 occurrence => required, opts => []},
+	 occurrence => optional, opts => []},
        #{name => message, fnum => 2, rnum => 3, type => string,
 	 occurrence => optional, opts => []}]},
      {{msg, 'Dependency'},
       [#{name => package, fnum => 1, rnum => 2,
-	 type => string, occurrence => required, opts => []},
+	 type => string, occurrence => optional, opts => []},
        #{name => requirement, fnum => 2, rnum => 3,
-	 type => string, occurrence => required, opts => []},
+	 type => string, occurrence => optional, opts => []},
        #{name => optional, fnum => 3, rnum => 4, type => bool,
 	 occurrence => optional, opts => []},
        #{name => app, fnum => 4, rnum => 5, type => string,
@@ -1380,9 +1523,9 @@ find_msg_def('Package') ->
        opts => []}];
 find_msg_def('Release') ->
     [#{name => version, fnum => 1, rnum => 2,
-       type => string, occurrence => required, opts => []},
+       type => string, occurrence => optional, opts => []},
      #{name => checksum, fnum => 2, rnum => 3, type => bytes,
-       occurrence => required, opts => []},
+       occurrence => optional, opts => []},
      #{name => dependencies, fnum => 3, rnum => 4,
        type => {msg, 'Dependency'}, occurrence => repeated,
        opts => []},
@@ -1392,14 +1535,14 @@ find_msg_def('Release') ->
 find_msg_def('RetirementStatus') ->
     [#{name => reason, fnum => 1, rnum => 2,
        type => {enum, 'RetirementReason'},
-       occurrence => required, opts => []},
+       occurrence => optional, opts => []},
      #{name => message, fnum => 2, rnum => 3, type => string,
        occurrence => optional, opts => []}];
 find_msg_def('Dependency') ->
     [#{name => package, fnum => 1, rnum => 2,
-       type => string, occurrence => required, opts => []},
+       type => string, occurrence => optional, opts => []},
      #{name => requirement, fnum => 2, rnum => 3,
-       type => string, occurrence => required, opts => []},
+       type => string, occurrence => optional, opts => []},
      #{name => optional, fnum => 3, rnum => 4, type => bool,
        occurrence => optional, opts => []},
      #{name => app, fnum => 4, rnum => 5, type => string,

--- a/src/hex_pb_signed.erl
+++ b/src/hex_pb_signed.erl
@@ -29,8 +29,8 @@
 
 %% message types
 -type 'Signed'() ::
-      #{payload                 => iodata(),        % = 1
-        signature               => iodata()         % = 2
+      #{%% payload              => iodata()         % = 1
+        %% signature            => iodata()         % = 2
        }.
 -export_type(['Signed'/0]).
 
@@ -41,10 +41,7 @@ encode_msg(Msg, MsgName) ->
 
 -spec encode_msg('Signed'(),'Signed', list()) -> binary().
 encode_msg(Msg, MsgName, Opts) ->
-    case proplists:get_bool(verify, Opts) of
-      true -> verify_msg(Msg, MsgName, Opts);
-      false -> ok
-    end,
+    verify_msg(Msg, MsgName, Opts),
     TrUserData = proplists:get_value(user_data, Opts),
     case MsgName of
       'Signed' -> e_msg_Signed(Msg, TrUserData)
@@ -355,7 +352,6 @@ verify_msg(Msg, MsgName, Opts) ->
     end.
 
 
--dialyzer({nowarn_function,v_msg_Signed/3}).
 v_msg_Signed(#{} = M, Path, _) ->
     case M of
       #{payload := F1} -> v_type_bytes(F1, [payload | Path]);
@@ -380,7 +376,6 @@ v_msg_Signed(M, Path, _TrUserData) when is_map(M) ->
 v_msg_Signed(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, 'Signed'}, X, Path).
 
--dialyzer({nowarn_function,v_type_bytes/2}).
 v_type_bytes(B, _Path) when is_binary(B) -> ok;
 v_type_bytes(B, _Path) when is_list(B) -> ok;
 v_type_bytes(X, Path) ->
@@ -393,12 +388,11 @@ mk_type_error(Error, ValueSeen, Path) ->
 		  {Error, [{value, ValueSeen}, {path, Path2}]}}).
 
 
--dialyzer({nowarn_function,prettify_path/1}).
 prettify_path([]) -> top_level;
 prettify_path(PathR) ->
-    list_to_atom(lists:append(lists:join(".",
-					 lists:map(fun atom_to_list/1,
-						   lists:reverse(PathR))))).
+    list_to_atom(string:join(lists:map(fun atom_to_list/1,
+				       lists:reverse(PathR)),
+			     ".")).
 
 
 -compile({inline,id/2}).

--- a/src/hex_pb_signed.erl
+++ b/src/hex_pb_signed.erl
@@ -29,8 +29,8 @@
 
 %% message types
 -type 'Signed'() ::
-      #{payload                 => iodata()         % = 1
-        %% signature            => iodata()         % = 2
+      #{payload                 => iodata(),        % = 1
+        signature               => iodata()         % = 2
        }.
 -export_type(['Signed'/0]).
 
@@ -41,7 +41,10 @@ encode_msg(Msg, MsgName) ->
 
 -spec encode_msg('Signed'(),'Signed', list()) -> binary().
 encode_msg(Msg, MsgName, Opts) ->
-    verify_msg(Msg, MsgName, Opts),
+    case proplists:get_bool(verify, Opts) of
+      true -> verify_msg(Msg, MsgName, Opts);
+      false -> ok
+    end,
     TrUserData = proplists:get_value(user_data, Opts),
     case MsgName of
       'Signed' -> e_msg_Signed(Msg, TrUserData)
@@ -53,16 +56,26 @@ e_msg_Signed(Msg, TrUserData) ->
     e_msg_Signed(Msg, <<>>, TrUserData).
 
 
-e_msg_Signed(#{payload := F1} = M, Bin, TrUserData) ->
-    B1 = begin
-	   TrF1 = id(F1, TrUserData),
-	   e_type_bytes(TrF1, <<Bin/binary, 10>>)
+e_msg_Signed(#{} = M, Bin, TrUserData) ->
+    B1 = case M of
+	   #{payload := F1} ->
+	       begin
+		 TrF1 = id(F1, TrUserData),
+		 case iolist_size(TrF1) of
+		   0 -> Bin;
+		   _ -> e_type_bytes(TrF1, <<Bin/binary, 10>>)
+		 end
+	       end;
+	   _ -> Bin
 	 end,
     case M of
       #{signature := F2} ->
 	  begin
 	    TrF2 = id(F2, TrUserData),
-	    e_type_bytes(TrF2, <<B1/binary, 18>>)
+	    case iolist_size(TrF2) of
+	      0 -> B1;
+	      _ -> e_type_bytes(TrF2, <<B1/binary, 18>>)
+	    end
 	  end;
       _ -> B1
     end.
@@ -117,8 +130,8 @@ decode_msg_2_doit('Signed', Bin, TrUserData) ->
 
 d_msg_Signed(Bin, TrUserData) ->
     dfp_read_field_def_Signed(Bin, 0, 0,
-			      id('$undef', TrUserData),
-			      id('$undef', TrUserData), TrUserData).
+			      id(<<>>, TrUserData), id(<<>>, TrUserData),
+			      TrUserData).
 
 dfp_read_field_def_Signed(<<10, Rest/binary>>, Z1, Z2,
 			  F@_1, F@_2, TrUserData) ->
@@ -129,9 +142,12 @@ dfp_read_field_def_Signed(<<18, Rest/binary>>, Z1, Z2,
     d_field_Signed_signature(Rest, Z1, Z2, F@_1, F@_2,
 			     TrUserData);
 dfp_read_field_def_Signed(<<>>, 0, 0, F@_1, F@_2, _) ->
-    S1 = #{payload => F@_1},
-    if F@_2 == '$undef' -> S1;
-       true -> S1#{signature => F@_2}
+    S1 = #{},
+    S2 = if F@_1 == '$undef' -> S1;
+	    true -> S1#{payload => F@_1}
+	 end,
+    if F@_2 == '$undef' -> S2;
+       true -> S2#{signature => F@_2}
     end;
 dfp_read_field_def_Signed(Other, Z1, Z2, F@_1, F@_2,
 			  TrUserData) ->
@@ -168,9 +184,12 @@ dg_read_field_def_Signed(<<0:1, X:7, Rest/binary>>, N,
 	  end
     end;
 dg_read_field_def_Signed(<<>>, 0, 0, F@_1, F@_2, _) ->
-    S1 = #{payload => F@_1},
-    if F@_2 == '$undef' -> S1;
-       true -> S1#{signature => F@_2}
+    S1 = #{},
+    S2 = if F@_1 == '$undef' -> S1;
+	    true -> S1#{payload => F@_1}
+	 end,
+    if F@_2 == '$undef' -> S2;
+       true -> S2#{signature => F@_2}
     end.
 
 d_field_Signed_payload(<<1:1, X:7, Rest/binary>>, N,
@@ -307,15 +326,21 @@ merge_msgs(Prev, New, MsgName, Opts) ->
       'Signed' -> merge_msg_Signed(Prev, New, TrUserData)
     end.
 
-merge_msg_Signed(#{} = PMsg,
-		 #{payload := NFpayload} = NMsg, _) ->
-    S1 = #{payload => NFpayload},
+merge_msg_Signed(PMsg, NMsg, _) ->
+    S1 = #{},
+    S2 = case {PMsg, NMsg} of
+	   {_, #{payload := NFpayload}} ->
+	       S1#{payload => NFpayload};
+	   {#{payload := PFpayload}, _} ->
+	       S1#{payload => PFpayload};
+	   _ -> S1
+	 end,
     case {PMsg, NMsg} of
       {_, #{signature := NFsignature}} ->
-	  S1#{signature => NFsignature};
+	  S2#{signature => NFsignature};
       {#{signature := PFsignature}, _} ->
-	  S1#{signature => PFsignature};
-      _ -> S1
+	  S2#{signature => PFsignature};
+      _ -> S2
     end.
 
 
@@ -330,8 +355,12 @@ verify_msg(Msg, MsgName, Opts) ->
     end.
 
 
-v_msg_Signed(#{payload := F1} = M, Path, _) ->
-    v_type_bytes(F1, [payload | Path]),
+-dialyzer({nowarn_function,v_msg_Signed/3}).
+v_msg_Signed(#{} = M, Path, _) ->
+    case M of
+      #{payload := F1} -> v_type_bytes(F1, [payload | Path]);
+      _ -> ok
+    end,
     case M of
       #{signature := F2} ->
 	  v_type_bytes(F2, [signature | Path]);
@@ -345,12 +374,13 @@ v_msg_Signed(#{payload := F1} = M, Path, _) ->
 		  maps:keys(M)),
     ok;
 v_msg_Signed(M, Path, _TrUserData) when is_map(M) ->
-    mk_type_error({missing_fields,
-		   [payload] -- maps:keys(M), 'Signed'},
+    mk_type_error({missing_fields, [] -- maps:keys(M),
+		   'Signed'},
 		  M, Path);
 v_msg_Signed(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, 'Signed'}, X, Path).
 
+-dialyzer({nowarn_function,v_type_bytes/2}).
 v_type_bytes(B, _Path) when is_binary(B) -> ok;
 v_type_bytes(B, _Path) when is_list(B) -> ok;
 v_type_bytes(X, Path) ->
@@ -363,11 +393,12 @@ mk_type_error(Error, ValueSeen, Path) ->
 		  {Error, [{value, ValueSeen}, {path, Path2}]}}).
 
 
+-dialyzer({nowarn_function,prettify_path/1}).
 prettify_path([]) -> top_level;
 prettify_path(PathR) ->
-    list_to_atom(string:join(lists:map(fun atom_to_list/1,
-				       lists:reverse(PathR)),
-			     ".")).
+    list_to_atom(lists:append(lists:join(".",
+					 lists:map(fun atom_to_list/1,
+						   lists:reverse(PathR))))).
 
 
 -compile({inline,id/2}).
@@ -377,7 +408,7 @@ id(X, _TrUserData) -> X.
 get_msg_defs() ->
     [{{msg, 'Signed'},
       [#{name => payload, fnum => 1, rnum => 2, type => bytes,
-	 occurrence => required, opts => []},
+	 occurrence => optional, opts => []},
        #{name => signature, fnum => 2, rnum => 3,
 	 type => bytes, occurrence => optional, opts => []}]}].
 
@@ -408,7 +439,7 @@ fetch_enum_def(EnumName) ->
 
 find_msg_def('Signed') ->
     [#{name => payload, fnum => 1, rnum => 2, type => bytes,
-       occurrence => required, opts => []},
+       occurrence => optional, opts => []},
      #{name => signature, fnum => 2, rnum => 3,
        type => bytes, occurrence => optional, opts => []}];
 find_msg_def(_) -> error.

--- a/src/hex_pb_versions.erl
+++ b/src/hex_pb_versions.erl
@@ -34,8 +34,8 @@
 -type 'Package'() ::
       #{name                    => iodata(),        % = 1
         versions                => [iodata()],      % = 2
-        retired                 => [integer()]      % = 3, 32 bits
-        %% repository           => iodata()         % = 4
+        retired                 => [integer()],     % = 3, 32 bits
+        repository              => iodata()         % = 4
        }.
 -export_type(['Versions'/0, 'Package'/0]).
 
@@ -46,7 +46,10 @@ encode_msg(Msg, MsgName) ->
 
 -spec encode_msg('Versions'() | 'Package'(),'Versions' | 'Package', list()) -> binary().
 encode_msg(Msg, MsgName, Opts) ->
-    verify_msg(Msg, MsgName, Opts),
+    case proplists:get_bool(verify, Opts) of
+      true -> verify_msg(Msg, MsgName, Opts);
+      false -> ok
+    end,
     TrUserData = proplists:get_value(user_data, Opts),
     case MsgName of
       'Versions' -> e_msg_Versions(Msg, TrUserData);
@@ -73,10 +76,17 @@ e_msg_Package(Msg, TrUserData) ->
     e_msg_Package(Msg, <<>>, TrUserData).
 
 
-e_msg_Package(#{name := F1} = M, Bin, TrUserData) ->
-    B1 = begin
-	   TrF1 = id(F1, TrUserData),
-	   e_type_string(TrF1, <<Bin/binary, 10>>)
+e_msg_Package(#{} = M, Bin, TrUserData) ->
+    B1 = case M of
+	   #{name := F1} ->
+	       begin
+		 TrF1 = id(F1, TrUserData),
+		 case is_empty_string(TrF1) of
+		   true -> Bin;
+		   false -> e_type_string(TrF1, <<Bin/binary, 10>>)
+		 end
+	       end;
+	   _ -> Bin
 	 end,
     B2 = case M of
 	   #{versions := F2} ->
@@ -98,7 +108,10 @@ e_msg_Package(#{name := F1} = M, Bin, TrUserData) ->
       #{repository := F4} ->
 	  begin
 	    TrF4 = id(F4, TrUserData),
-	    e_type_string(TrF4, <<B3/binary, 34>>)
+	    case is_empty_string(TrF4) of
+	      true -> B3;
+	      false -> e_type_string(TrF4, <<B3/binary, 34>>)
+	    end
 	  end;
       _ -> B3
     end.
@@ -154,6 +167,25 @@ e_varint(N, Bin) when N =< 127 -> <<Bin/binary, N>>;
 e_varint(N, Bin) ->
     Bin2 = <<Bin/binary, (N band 127 bor 128)>>,
     e_varint(N bsr 7, Bin2).
+
+is_empty_string("") -> true;
+is_empty_string(<<>>) -> true;
+is_empty_string(L) when is_list(L) ->
+    not string_has_chars(L);
+is_empty_string(B) when is_binary(B) -> false.
+
+string_has_chars([C | _]) when is_integer(C) -> true;
+string_has_chars([H | T]) ->
+    case string_has_chars(H) of
+      true -> true;
+      false -> string_has_chars(T)
+    end;
+string_has_chars(B)
+    when is_binary(B), byte_size(B) =/= 0 ->
+    true;
+string_has_chars(C) when is_integer(C) -> true;
+string_has_chars(<<>>) -> false;
+string_has_chars([]) -> false.
 
 
 decode_msg(Bin, MsgName) when is_binary(Bin) ->
@@ -291,8 +323,8 @@ skip_64_Versions(<<_:64, Rest/binary>>, Z1, Z2, F@_1,
 
 d_msg_Package(Bin, TrUserData) ->
     dfp_read_field_def_Package(Bin, 0, 0,
-			       id('$undef', TrUserData), id([], TrUserData),
-			       id([], TrUserData), id('$undef', TrUserData),
+			       id(<<>>, TrUserData), id([], TrUserData),
+			       id([], TrUserData), id(<<>>, TrUserData),
 			       TrUserData).
 
 dfp_read_field_def_Package(<<10, Rest/binary>>, Z1, Z2,
@@ -317,11 +349,13 @@ dfp_read_field_def_Package(<<34, Rest/binary>>, Z1, Z2,
 			       F@_3, F@_4, TrUserData);
 dfp_read_field_def_Package(<<>>, 0, 0, F@_1, R1, R2,
 			   F@_4, TrUserData) ->
-    S1 = #{name => F@_1,
-	   versions => lists_reverse(R1, TrUserData),
+    S1 = #{versions => lists_reverse(R1, TrUserData),
 	   retired => lists_reverse(R2, TrUserData)},
-    if F@_4 == '$undef' -> S1;
-       true -> S1#{repository => F@_4}
+    S2 = if F@_1 == '$undef' -> S1;
+	    true -> S1#{name => F@_1}
+	 end,
+    if F@_4 == '$undef' -> S2;
+       true -> S2#{repository => F@_4}
     end;
 dfp_read_field_def_Package(Other, Z1, Z2, F@_1, F@_2,
 			   F@_3, F@_4, TrUserData) ->
@@ -373,11 +407,13 @@ dg_read_field_def_Package(<<0:1, X:7, Rest/binary>>, N,
     end;
 dg_read_field_def_Package(<<>>, 0, 0, F@_1, R1, R2,
 			  F@_4, TrUserData) ->
-    S1 = #{name => F@_1,
-	   versions => lists_reverse(R1, TrUserData),
+    S1 = #{versions => lists_reverse(R1, TrUserData),
 	   retired => lists_reverse(R2, TrUserData)},
-    if F@_4 == '$undef' -> S1;
-       true -> S1#{repository => F@_4}
+    S2 = if F@_1 == '$undef' -> S1;
+	    true -> S1#{name => F@_1}
+	 end,
+    if F@_4 == '$undef' -> S2;
+       true -> S2#{repository => F@_4}
     end.
 
 d_field_Package_name(<<1:1, X:7, Rest/binary>>, N, Acc,
@@ -597,36 +633,40 @@ merge_msg_Versions(PMsg, NMsg, TrUserData) ->
       {_, _} -> S1
     end.
 
-merge_msg_Package(#{} = PMsg, #{name := NFname} = NMsg,
-		  TrUserData) ->
-    S1 = #{name => NFname},
+merge_msg_Package(PMsg, NMsg, TrUserData) ->
+    S1 = #{},
     S2 = case {PMsg, NMsg} of
-	   {#{versions := PFversions},
-	    #{versions := NFversions}} ->
-	       S1#{versions =>
-		       'erlang_++'(PFversions, NFversions, TrUserData)};
-	   {_, #{versions := NFversions}} ->
-	       S1#{versions => NFversions};
-	   {#{versions := PFversions}, _} ->
-	       S1#{versions => PFversions};
-	   {_, _} -> S1
+	   {_, #{name := NFname}} -> S1#{name => NFname};
+	   {#{name := PFname}, _} -> S1#{name => PFname};
+	   _ -> S1
 	 end,
     S3 = case {PMsg, NMsg} of
+	   {#{versions := PFversions},
+	    #{versions := NFversions}} ->
+	       S2#{versions =>
+		       'erlang_++'(PFversions, NFversions, TrUserData)};
+	   {_, #{versions := NFversions}} ->
+	       S2#{versions => NFversions};
+	   {#{versions := PFversions}, _} ->
+	       S2#{versions => PFversions};
+	   {_, _} -> S2
+	 end,
+    S4 = case {PMsg, NMsg} of
 	   {#{retired := PFretired}, #{retired := NFretired}} ->
-	       S2#{retired =>
+	       S3#{retired =>
 		       'erlang_++'(PFretired, NFretired, TrUserData)};
 	   {_, #{retired := NFretired}} ->
-	       S2#{retired => NFretired};
+	       S3#{retired => NFretired};
 	   {#{retired := PFretired}, _} ->
-	       S2#{retired => PFretired};
-	   {_, _} -> S2
+	       S3#{retired => PFretired};
+	   {_, _} -> S3
 	 end,
     case {PMsg, NMsg} of
       {_, #{repository := NFrepository}} ->
-	  S3#{repository => NFrepository};
+	  S4#{repository => NFrepository};
       {#{repository := PFrepository}, _} ->
-	  S3#{repository => PFrepository};
-      _ -> S3
+	  S4#{repository => PFrepository};
+      _ -> S4
     end.
 
 
@@ -644,6 +684,7 @@ verify_msg(Msg, MsgName, Opts) ->
     end.
 
 
+-dialyzer({nowarn_function,v_msg_Versions/3}).
 v_msg_Versions(#{} = M, Path, TrUserData) ->
     case M of
       #{packages := F1} ->
@@ -670,8 +711,12 @@ v_msg_Versions(M, Path, _TrUserData) when is_map(M) ->
 v_msg_Versions(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, 'Versions'}, X, Path).
 
-v_msg_Package(#{name := F1} = M, Path, _) ->
-    v_type_string(F1, [name | Path]),
+-dialyzer({nowarn_function,v_msg_Package/3}).
+v_msg_Package(#{} = M, Path, _) ->
+    case M of
+      #{name := F1} -> v_type_string(F1, [name | Path]);
+      _ -> ok
+    end,
     case M of
       #{versions := F2} ->
 	  if is_list(F2) ->
@@ -711,12 +756,13 @@ v_msg_Package(#{name := F1} = M, Path, _) ->
 		  maps:keys(M)),
     ok;
 v_msg_Package(M, Path, _TrUserData) when is_map(M) ->
-    mk_type_error({missing_fields, [name] -- maps:keys(M),
+    mk_type_error({missing_fields, [] -- maps:keys(M),
 		   'Package'},
 		  M, Path);
 v_msg_Package(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, 'Package'}, X, Path).
 
+-dialyzer({nowarn_function,v_type_int32/2}).
 v_type_int32(N, _Path)
     when -2147483648 =< N, N =< 2147483647 ->
     ok;
@@ -727,6 +773,7 @@ v_type_int32(X, Path) ->
     mk_type_error({bad_integer, int32, signed, 32}, X,
 		  Path).
 
+-dialyzer({nowarn_function,v_type_string/2}).
 v_type_string(S, Path) when is_list(S); is_binary(S) ->
     try unicode:characters_to_binary(S) of
       B when is_binary(B) -> ok;
@@ -746,11 +793,12 @@ mk_type_error(Error, ValueSeen, Path) ->
 		  {Error, [{value, ValueSeen}, {path, Path2}]}}).
 
 
+-dialyzer({nowarn_function,prettify_path/1}).
 prettify_path([]) -> top_level;
 prettify_path(PathR) ->
-    list_to_atom(string:join(lists:map(fun atom_to_list/1,
-				       lists:reverse(PathR)),
-			     ".")).
+    list_to_atom(lists:append(lists:join(".",
+					 lists:map(fun atom_to_list/1,
+						   lists:reverse(PathR))))).
 
 
 -compile({inline,id/2}).
@@ -771,7 +819,7 @@ get_msg_defs() ->
 	 opts => []}]},
      {{msg, 'Package'},
       [#{name => name, fnum => 1, rnum => 2, type => string,
-	 occurrence => required, opts => []},
+	 occurrence => optional, opts => []},
        #{name => versions, fnum => 2, rnum => 3,
 	 type => string, occurrence => repeated, opts => []},
        #{name => retired, fnum => 3, rnum => 4, type => int32,
@@ -810,7 +858,7 @@ find_msg_def('Versions') ->
        opts => []}];
 find_msg_def('Package') ->
     [#{name => name, fnum => 1, rnum => 2, type => string,
-       occurrence => required, opts => []},
+       occurrence => optional, opts => []},
      #{name => versions, fnum => 2, rnum => 3,
        type => string, occurrence => repeated, opts => []},
      #{name => retired, fnum => 3, rnum => 4, type => int32,

--- a/src/hex_pb_versions.erl
+++ b/src/hex_pb_versions.erl
@@ -32,10 +32,10 @@
       #{packages                => ['Package'()]    % = 1
        }.
 -type 'Package'() ::
-      #{name                    => iodata(),        % = 1
+      #{%% name                 => iodata(),        % = 1
         versions                => [iodata()],      % = 2
-        retired                 => [integer()],     % = 3, 32 bits
-        repository              => iodata()         % = 4
+        retired                 => [integer()]      % = 3, 32 bits
+        %% repository           => iodata()         % = 4
        }.
 -export_type(['Versions'/0, 'Package'/0]).
 
@@ -46,10 +46,7 @@ encode_msg(Msg, MsgName) ->
 
 -spec encode_msg('Versions'() | 'Package'(),'Versions' | 'Package', list()) -> binary().
 encode_msg(Msg, MsgName, Opts) ->
-    case proplists:get_bool(verify, Opts) of
-      true -> verify_msg(Msg, MsgName, Opts);
-      false -> ok
-    end,
+    verify_msg(Msg, MsgName, Opts),
     TrUserData = proplists:get_value(user_data, Opts),
     case MsgName of
       'Versions' -> e_msg_Versions(Msg, TrUserData);
@@ -684,7 +681,6 @@ verify_msg(Msg, MsgName, Opts) ->
     end.
 
 
--dialyzer({nowarn_function,v_msg_Versions/3}).
 v_msg_Versions(#{} = M, Path, TrUserData) ->
     case M of
       #{packages := F1} ->
@@ -711,7 +707,6 @@ v_msg_Versions(M, Path, _TrUserData) when is_map(M) ->
 v_msg_Versions(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, 'Versions'}, X, Path).
 
--dialyzer({nowarn_function,v_msg_Package/3}).
 v_msg_Package(#{} = M, Path, _) ->
     case M of
       #{name := F1} -> v_type_string(F1, [name | Path]);
@@ -762,7 +757,6 @@ v_msg_Package(M, Path, _TrUserData) when is_map(M) ->
 v_msg_Package(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, 'Package'}, X, Path).
 
--dialyzer({nowarn_function,v_type_int32/2}).
 v_type_int32(N, _Path)
     when -2147483648 =< N, N =< 2147483647 ->
     ok;
@@ -773,7 +767,6 @@ v_type_int32(X, Path) ->
     mk_type_error({bad_integer, int32, signed, 32}, X,
 		  Path).
 
--dialyzer({nowarn_function,v_type_string/2}).
 v_type_string(S, Path) when is_list(S); is_binary(S) ->
     try unicode:characters_to_binary(S) of
       B when is_binary(B) -> ok;
@@ -793,12 +786,11 @@ mk_type_error(Error, ValueSeen, Path) ->
 		  {Error, [{value, ValueSeen}, {path, Path2}]}}).
 
 
--dialyzer({nowarn_function,prettify_path/1}).
 prettify_path([]) -> top_level;
 prettify_path(PathR) ->
-    list_to_atom(lists:append(lists:join(".",
-					 lists:map(fun atom_to_list/1,
-						   lists:reverse(PathR))))).
+    list_to_atom(string:join(lists:map(fun atom_to_list/1,
+				       lists:reverse(PathR)),
+			     ".")).
 
 
 -compile({inline,id/2}).

--- a/src/hex_registry.erl
+++ b/src/hex_registry.erl
@@ -64,7 +64,7 @@ decode_signed(Signed) ->
 
 %% @doc
 %% Decode message created with sign_protobuf/2 and verify it against public key.
--spec decode_and_verify_signed(map(), public_key()) -> {ok, binary()} | {error, term()}.
+-spec decode_and_verify_signed(binary(), public_key()) -> {ok, binary()} | {error, term()}.
 decode_and_verify_signed(Signed, PublicKey) ->
     #{payload := Payload, signature := Signature} = decode_signed(Signed),
     case verify(Payload, Signature, PublicKey) of

--- a/test/hex_registry_SUITE.erl
+++ b/test/hex_registry_SUITE.erl
@@ -16,11 +16,11 @@ names_test(_Config) ->
     Names = #{
         packages => [
             #{name => <<"foo">>, repository => <<"hexpm">>},
-            #{name => <<"bar">>}
+            #{name => <<"bar">>, repository => <<>>}
         ]
     },
     Payload = hex_registry:encode_names(Names),
-    Names = hex_registry:decode_names(Payload),
+    ?assertMatch(Names, hex_registry:decode_names(Payload)),
     ok.
 
 versions_test(_Config) ->
@@ -35,12 +35,13 @@ versions_test(_Config) ->
             #{
                 name => <<"bar">>,
                 versions => [<<"1.0.0">>],
-                retired => []
+                retired => [],
+                repository => <<>>
             }
         ]
     },
     Payload = hex_registry:encode_versions(Versions),
-    Versions = hex_registry:decode_versions(Payload),
+    ?assertMatch(Versions, hex_registry:decode_versions(Payload)),
     ok.
 
 package_test(_Config) ->
@@ -59,7 +60,10 @@ package_test(_Config) ->
                     },
                     #{
                         package => <<"bar">>,
-                        requirement => <<"~> 1.0">>
+                        requirement => <<"~> 1.0">>,
+                        optional => false,
+                        app => <<>>,
+                        repository => <<>>
                     }
                 ],
                 retired => #{
@@ -70,7 +74,7 @@ package_test(_Config) ->
         ]
     },
     Payload = hex_registry:encode_package(Package),
-    Package = hex_registry:decode_package(Payload),
+    ?assertMatch(Package, hex_registry:decode_package(Payload)),
     ok.
 
 signed_test(_Config) ->


### PR DESCRIPTION
This updates to proto3 and fixes a few other dialyzer warnings.

The main dialyzer related changes were just one in `hex_http`, `hex_erl_tar.hrl` and `hex_registry`

I removed the gpb option to target 17. I don't think it is necessary, but we'll see when the tests run on 17 in travis :), except for type specs, which may as well only need to be correct for the latest otp and dialyzed only on otp-21.

I had to remove `{verify, always}` and replace it with optional. I opened an issue with gpb because the issue really confuses me https://github.com/tomas-abrahamsson/gpb/issues/149

It is marked `wip` because the `hex_tarball_SUITE` `disk_test` checksum comparison currently fails. It doesn't seem protos are included in any way in the tarballs, right? I can't find what would have changed to cause this, so I am leaving it failing until I do and can fix it.