### PR TITLE
return whole response tuple from request always

### DIFF
--- a/src/hex_api.erl
+++ b/src/hex_api.erl
@@ -51,7 +51,7 @@ request(Config, Method, Path, Body) when is_binary(Path) and is_map(Config) ->
     ReqHeaders2 = put_new(<<"accept">>, ?ERL_CONTENT_TYPE, ReqHeaders),
 
     case hex_http:request(Config, Method, build_url(Path, Config), ReqHeaders2, Body) of
-        {ok, {Status, RespHeaders, RespBody} = Response} ->
+        {ok, {Status, RespHeaders, RespBody}} = Response ->
             ContentType = maps:get(<<"content-type">>, RespHeaders, <<"">>),
             case binary:match(ContentType, ?ERL_CONTENT_TYPE) of
                 {_, _} ->


### PR DESCRIPTION
Just discovered this because it results in `hex_api_release:delete` returning `{Code, Headers, Body}` instead of `{ok, {Code, Headers, Body}}` and I assume we want a consistent return type for these.