### PR TITLE
Remove deprecated repository field from hex_registry returns

### DIFF
--- a/src/hex_registry.erl
+++ b/src/hex_registry.erl
@@ -29,7 +29,8 @@ encode_names(Names) ->
 %% @doc
 %% Decode message created with encode_names/1.
 decode_names(Payload) ->
-    hex_pb_names:decode_msg(Payload, 'Names').
+    Names = hex_pb_names:decode_msg(Payload, 'Names'),
+    remove_deprecated_repository_field(Names).
 
 %% @doc
 %% Encode Versions message.
@@ -39,7 +40,11 @@ encode_versions(Versions) ->
 %% @doc
 %% Decode message created with encode_versions/1.
 decode_versions(Payload) ->
-    hex_pb_versions:decode_msg(Payload, 'Versions').
+    Versions = hex_pb_versions:decode_msg(Payload, 'Versions'),
+    remove_deprecated_repository_field(Versions).
+
+remove_deprecated_repository_field(#{packages := Packages} = Map) when is_list(Packages) ->
+    maps:put(packages, lists:map(fun(Map2) -> maps:remove(repository, Map2) end, Packages), Map).
 
 %% @doc
 %% Encode Package message.

--- a/test/hex_registry_SUITE.erl
+++ b/test/hex_registry_SUITE.erl
@@ -16,8 +16,8 @@ names_test(_Config) ->
     Names = #{
         repository => <<"hexpm">>,
         packages => [
-            #{name => <<"foo">>, repository => <<>>},
-            #{name => <<"bar">>, repository => <<>>}
+            #{name => <<"foo">>},
+            #{name => <<"bar">>}
         ]
     },
     Payload = hex_registry:encode_names(Names),
@@ -31,14 +31,12 @@ versions_test(_Config) ->
             #{
                 name => <<"foo">>,
                 versions => [<<"1.0.0-rc.1">>, <<"1.1.0-rc.2">>, <<"1.1.0">>],
-                retired => [0, 1],
-                repository => <<>>
+                retired => [0, 1]
             },
             #{
                 name => <<"bar">>,
                 versions => [<<"1.0.0">>],
-                retired => [],
-                repository => <<>>
+                retired => []
             }
         ]
     },


### PR DESCRIPTION
In https://github.com/hexpm/hex_core/pull/45/files#diff-11cefc435b36c8e79aed2fcb56834766L18 we removed however it came back after upgrading to proto3. Since the field is deprecated we shouldn't return it in `hex_core` functions, either in a new patch release v0.3.1 or later in v0.4.0. I prefer to remove it in v0.3.1.