### PR TITLE
Include ssl and inets in applications list

### DIFF
--- a/src/hex_core.app.src
+++ b/src/hex_core.app.src
@@ -2,7 +2,7 @@
   {description, "Reference implementation of Hex specifications"},
   {vsn, "0.3.0"},
   {registered, []},
-  {applications, [kernel, stdlib]},
+  {applications, [kernel, stdlib, ssl, inets]},
   {licenses, ["Apache 2.0"]},
   {links, [
     {"GitHub", "https://github.com/hexpm/hex_core"},


### PR DESCRIPTION
I'm not 100% sure if it's the right thing to do, we only need inets for built-in (yet optional) `hex_http_httpc` adapter and we can use it without https. Alternative is to add some runtime code, e.g. httpc adapter could do `application:ensure_started(inets)` and start ssl if detected https URL. Although ssl would likely be required for 3rd party adapters too so not sure if they should duplicate that code. I'm leaning towards adding just ssl or both to application list.

@ericmj @tsloughter Thoughts?