### PR TITLE
Add all possible fields to hex_core config

### DIFF
--- a/src/hex_api.erl
+++ b/src/hex_api.erl
@@ -84,7 +84,7 @@ encode_body(Body) ->
 make_headers(Config) ->
     maps:fold(fun set_header/3, #{}, Config).
 
-set_header(api_key, Token, Headers) -> maps:put(<<"authorization">>, Token, Headers);
+set_header(api_key, Token, Headers) when is_binary(Token) -> maps:put(<<"authorization">>, Token, Headers);
 set_header(_, _, Headers) -> Headers.
 
 put_new(Key, Value, Map) ->

--- a/src/hex_core.erl
+++ b/src/hex_core.erl
@@ -16,30 +16,35 @@ J1i2xWFndWa6nfFnRxZmCStCOZWYYPlaxr+FZceFbpMwzTNs4g3d4tLNUcbKAIH4
 
 
 -type config() :: #{
+    api_key => binary() | undefined,
     api_url => binary(),
-    api_key => binary(),
     http_adapter => module(),
     http_etag => binary(),
+    http_adapter_config => map(),
     http_user_agent_fragment => binary(),
+    organization => binary() | undefined,
+    repo_key => binary() | undefined,
     repo_name => binary(),
-    repo_key => binary(),
-    repo_url => binary(),
     repo_public_key => binary(),
+    repo_url => binary(),
     repo_verify => boolean(),
-    repo_verify_origin => boolean(),
-    organization => binary()
+    repo_verify_origin => boolean()
 }.
 
 -spec default_config() -> config().
 default_config() ->
     #{
+        api_key => undefined,
         api_url => <<"https://hex.pm/api">>,
         http_adapter => hex_http_httpc,
         http_adapter_config => #{profile => default},
+        http_etag => undefined,
         http_user_agent_fragment => <<"(httpc)">>,
+        organization => undefined,
+        repo_key => undefined,
         repo_name => <<"hexpm">>,
-        repo_url => <<"https://repo.hex.pm">>,
         repo_public_key => ?HEXPM_PUBLIC_KEY,
+        repo_url => <<"https://repo.hex.pm">>,
         repo_verify => true,
         repo_verify_origin => true
     }.

--- a/src/hex_core.erl
+++ b/src/hex_core.erl
@@ -19,7 +19,7 @@ J1i2xWFndWa6nfFnRxZmCStCOZWYYPlaxr+FZceFbpMwzTNs4g3d4tLNUcbKAIH4
     api_key => binary() | undefined,
     api_url => binary(),
     http_adapter => module(),
-    http_etag => binary(),
+    http_etag => binary() | undefined,
     http_adapter_config => map(),
     http_user_agent_fragment => binary(),
     organization => binary() | undefined,

--- a/src/hex_repo.erl
+++ b/src/hex_repo.erl
@@ -165,6 +165,6 @@ tarball_filename(Name, Version) ->
 make_headers(Config) ->
     maps:fold(fun set_header/3, #{}, Config).
 
-set_header(http_etag, ETag, Headers) -> maps:put(<<"if-none-match">>, ETag, Headers);
-set_header(repo_key, Token, Headers) -> maps:put(<<"authorization">>, Token, Headers);
+set_header(http_etag, ETag, Headers) when is_binary(ETag) -> maps:put(<<"if-none-match">>, ETag, Headers);
+set_header(repo_key, Token, Headers) when is_binary(Token) -> maps:put(<<"authorization">>, Token, Headers);
 set_header(_, _, Headers) -> Headers.


### PR DESCRIPTION
The idea is to mostly document it, e.g. by running `hex_core:default_config()` we could see all available fields.

I guess we could have _just_ documented it in the type instead, differentiate required and optional keys with `#{... => ..., ... := ...}` in `hex_core:config()` type, however I believe this syntax wasn't supported in OTP 17.

I've used `undefined` as the default value. In some places we're using `nil` so I guess we should standardise on `undefined` everywhere?

cc @tsloughter