### PR TITLE
Add and export hex_core:version/0

### DIFF
--- a/src/hex_core.erl
+++ b/src/hex_core.erl
@@ -1,5 +1,8 @@
 -module(hex_core).
--export([default_config/0]).
+
+-include("hex_core.hrl").
+
+-export([default_config/0, version/0]).
 
 -export_type([config/0]).
 
@@ -48,3 +51,6 @@ default_config() ->
         repo_verify => true,
         repo_verify_origin => true
     }.
+
+version() ->
+  ?HEX_CORE_VERSION.

--- a/test/hex_core_SUITE.erl
+++ b/test/hex_core_SUITE.erl
@@ -1,0 +1,13 @@
+-module(hex_core_SUITE).
+
+-compile([export_all]).
+
+-include("hex_core.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+all() ->
+    [version_test].
+
+version_test(_Config) ->
+  ?assertEqual(?HEX_CORE_VERSION, hex_core:version()).


### PR DESCRIPTION
  - Added version/0 to hex_core which is intended to be used for
  backwards compat work-arounds by other apps and libs.