### PR TITLE
Build up an org repo url if org is set

### DIFF
--- a/src/hex_repo.erl
+++ b/src/hex_repo.erl
@@ -97,10 +97,9 @@ get_package(#{repo_name := Repository} = Config, Name) when is_binary(Name) and 
 %% '''
 %% @end
 get_tarball(Config, Name, Version) ->
-    URI = maps:get(repo_url, Config),
     ReqHeaders = make_headers(Config),
 
-    case get(Config, tarball_url(URI, Name, Version), ReqHeaders) of
+    case get(Config, tarball_url(Name, Version, Config), ReqHeaders) of
         {ok, {200, RespHeaders, Tarball}} ->
             {ok, {200, RespHeaders, Tarball}};
 
@@ -150,7 +149,10 @@ decode(Signed, PublicKey, Decoder, Config) ->
             Decoder(Payload)
     end.
 
-tarball_url(URI, Name, Version) ->
+tarball_url(Name, Version, #{repo_url := URI, organization := Org}) when is_binary(Org) ->
+    Filename = tarball_filename(Name, Version),
+    <<URI/binary, "/repos/", Org/binary, "/tarballs/", Filename/binary>>;
+tarball_url(Name, Version, #{repo_url := URI}) ->
     Filename = tarball_filename(Name, Version),
     <<URI/binary, "/tarballs/", Filename/binary>>.
 

--- a/test/hex_repo_SUITE.erl
+++ b/test/hex_repo_SUITE.erl
@@ -19,7 +19,7 @@ suite() ->
     [{require, {ssl_certs, test_pub}}].
 
 all() ->
-    [get_names_test, get_versions_test, get_package_test, get_tarball_test].
+    [get_names_test, get_versions_test, get_package_test, get_tarball_test, get_tarball_org_test].
 
 get_names_test(_Config) ->
     {ok, {200, _, Packages}} = hex_repo:get_names(?CONFIG),
@@ -48,4 +48,14 @@ get_tarball_test(_Config) ->
     {ok, {304, _, _}} = hex_repo:get_tarball(maps:put(http_etag, ETag, ?CONFIG), <<"ecto">>, <<"1.0.0">>),
 
     {ok, {403, _, _}} = hex_repo:get_tarball(?CONFIG, <<"ecto">>, <<"9.9.9">>),
+    ok.
+
+get_tarball_org_test(_Config) ->
+    OrgConfig = maps:merge(?CONFIG, #{organization => <<"org">>}),
+    {ok, {200, #{<<"etag">> := ETag}, Tarball}} = hex_repo:get_tarball(OrgConfig, <<"ecto">>, <<"1.0.0">>),
+    {ok, _} = hex_tarball:unpack(Tarball, memory),
+
+    {ok, {304, _, _}} = hex_repo:get_tarball(maps:put(http_etag, ETag, OrgConfig), <<"ecto">>, <<"1.0.0">>),
+
+    {ok, {403, _, _}} = hex_repo:get_tarball(OrgConfig, <<"ecto">>, <<"9.9.9">>),
     ok.

--- a/test/support/hex_http_test.erl
+++ b/test/support/hex_http_test.erl
@@ -3,6 +3,7 @@
 -export([request/5]).
 -define(TEST_REPO_URL, "https://repo.test").
 -define(TEST_API_URL, "https://api.test").
+-define(TEST_ORG_URL, "https://repo.test/repos/org").
 -define(PRIVATE_KEY, ct:get_config({ssl_certs, test_priv})).
 -define(PUBLIC_KEY, ct:get_config({ssl_certs, test_pub}).
 
@@ -81,6 +82,17 @@ fixture(get, <<?TEST_REPO_URL, "/packages/ecto">>, _, _) ->
     {ok, {200, Headers, Compressed}};
 
 fixture(get, <<?TEST_REPO_URL, "/tarballs/ecto-1.0.0.tar">>, _, _) ->
+    Headers = #{
+      <<"etag">> => <<"\"dummy\"">>
+    },
+    Metadata = #{
+        <<"name">> => <<"ecto">>,
+        <<"version">> => <<"1.0.0">>
+    },
+    {ok, {Tarball, _Checksum}} = hex_tarball:create(Metadata, []),
+    {ok, {200, Headers, Tarball}};
+
+fixture(get, <<?TEST_ORG_URL, "/tarballs/ecto-1.0.0.tar">>, _, _) ->
     Headers = #{
       <<"etag">> => <<"\"dummy\"">>
     },


### PR DESCRIPTION
Since we're handing off url building to hex_core then `tarball_url/3` function should act like `build_url/2`. This probably requires a change to mix hex as presumably it's currently building up the url. After this is merged we'll be finishing up a patch so that fetching private packages in rebar3 works. 