### PR TITLE
Default to undefined repo_organization when key does not exist

### DIFF
--- a/src/hex_repo.erl
+++ b/src/hex_repo.erl
@@ -159,7 +159,9 @@ tarball_url(Config, Name, Version) ->
 build_url(#{repo_url := URI, repo_organization := Org}, Path) when is_binary(Org) ->
     <<URI/binary, "/repos/", Org/binary, "/", Path/binary>>;
 build_url(#{repo_url := URI, repo_organization := undefined}, Path) ->
-    <<URI/binary, "/", Path/binary>>.
+    <<URI/binary, "/", Path/binary>>;
+build_url(Config, Path) ->
+    build_url(Config#{repo_organization => undefined}, Path).
 
 tarball_filename(Name, Version) ->
     <<Name/binary, "-", Version/binary, ".tar">>.

--- a/test/hex_repo_SUITE.erl
+++ b/test/hex_repo_SUITE.erl
@@ -17,7 +17,7 @@ suite() ->
     [{require, {ssl_certs, test_pub}}].
 
 all() ->
-    [get_names_test, get_versions_test, get_package_test, get_tarball_test].
+    [get_names_test, get_versions_test, get_package_test, get_tarball_test, repo_org_not_set].
 
 get_names_test(_Config) ->
     {ok, {200, _, Packages}} = hex_repo:get_names(?CONFIG),
@@ -46,4 +46,13 @@ get_tarball_test(_Config) ->
     {ok, {304, _, _}} = hex_repo:get_tarball(maps:put(http_etag, ETag, ?CONFIG), <<"ecto">>, <<"1.0.0">>),
 
     {ok, {403, _, _}} = hex_repo:get_tarball(?CONFIG, <<"ecto">>, <<"9.9.9">>),
+    ok.
+
+repo_org_not_set(_Config) ->
+    Config = maps:remove(repo_organization, ?CONFIG),
+    {ok, {200, _, Releases}} = hex_repo:get_package(Config, <<"ecto">>),
+    [#{version := <<"1.0.0">>}] =
+        lists:filter(fun(#{version := Version}) -> Version == <<"1.0.0">> end, Releases),
+
+    {ok, {403, _, _}} = hex_repo:get_package(Config, <<"nonexisting">>),
     ok.


### PR DESCRIPTION
  In the case where repo_organization key/value is not present in a
 repository configuration set the key to undefined.

Note that this needs to be back ported to a maintenance tag for 0.5.0 for rebar3 if this PR is accepted. 