### PR TITLE
Add hex_api_auth:test_key/3

### DIFF
--- a/src/hex_api_auth.erl
+++ b/src/hex_api_auth.erl
@@ -7,9 +7,7 @@
 %% Examples:
 %%
 %% ```
-%% 1> Params = #{domain, <<"repository">>, {resource, <<"gustafson_motors">>}}.
-%% #{domain => <<"repository">>,
-%%   resource => <<"gustafson_motors">>}
+%% 1> Params = #{domain => <<"repository">>, resource => <<"gustafson_motors">>}.
 %% 2> hex_api_auth:test_key(hex_core:default_config(), Params).
 %% {ok,{204, ..., nil}}
 %% '''

--- a/src/hex_api_auth.erl
+++ b/src/hex_api_auth.erl
@@ -1,0 +1,26 @@
+-module(hex_api_auth).
+-export([
+    test_key/3
+]).
+
+-define(ERL_CONTENT_TYPE, <<"application/vnd.hex+erlang">>).
+
+%% @doc
+%% Test an auth key against a given domain and resource.
+%%
+%% Examples:
+%%
+%% ```
+%% 1> Params = [{domain, <<"repository">>}, {resource, <<"gustafson_motors">>}].
+%% [{domain,<<"repository">>},
+%% {resource,<<"gustafson_motors">>}]
+%% 2> Key = <<"86c4ac12292843b66fdee41e022f8497">>
+%% 2> hex_api_auth:test_key(hex_core:default_config(), Params, Key).
+%% {ok,{204, ..., nil}}
+%% '''
+%% @end
+-spec test_key(map(), map(),  binary()) -> hex_api:response().
+test_key(Repo, Params, Key) ->
+    ParamList = maps:to_list(Params),
+    URI = ["auth?", hex_api:encode_query_string(ParamList)],
+    hex_api:get(Repo#{api_key => Key}, list_to_binary(URI)).

--- a/src/hex_api_auth.erl
+++ b/src/hex_api_auth.erl
@@ -1,9 +1,5 @@
 -module(hex_api_auth).
--export([
-    test_key/3
-]).
-
--define(ERL_CONTENT_TYPE, <<"application/vnd.hex+erlang">>).
+-export([test/2]).
 
 %% @doc
 %% Test an auth key against a given domain and resource.
@@ -11,16 +7,14 @@
 %% Examples:
 %%
 %% ```
-%% 1> Params = [{domain, <<"repository">>}, {resource, <<"gustafson_motors">>}].
-%% [{domain,<<"repository">>},
-%% {resource,<<"gustafson_motors">>}]
-%% 2> Key = <<"86c4ac12292843b66fdee41e022f8497">>
-%% 2> hex_api_auth:test_key(hex_core:default_config(), Params, Key).
+%% 1> Params = #{domain, <<"repository">>, {resource, <<"gustafson_motors">>}}.
+%% #{domain => <<"repository">>,
+%%   resource => <<"gustafson_motors">>}
+%% 2> hex_api_auth:test_key(hex_core:default_config(), Params).
 %% {ok,{204, ..., nil}}
 %% '''
 %% @end
--spec test_key(map(), map(),  binary()) -> hex_api:response().
-test_key(Repo, Params, Key) ->
-    ParamList = maps:to_list(Params),
-    URI = ["auth?", hex_api:encode_query_string(ParamList)],
-    hex_api:get(Repo#{api_key => Key}, list_to_binary(URI)).
+-spec test(hex_core:config(), map()) -> hex_api:response().
+test(Config, #{domain := Domain, resource := Resource}) ->
+    URI = ["auth", "?domain=", Domain, "&resource=", Resource],
+    hex_api:get(Config, list_to_binary(URI)).

--- a/test/hex_api_SUITE.erl
+++ b/test/hex_api_SUITE.erl
@@ -55,7 +55,7 @@ owner_test(_Config) ->
 
 auth_test(_Config) ->
     Params = #{domain => <<"repository">>, resource => <<"gustafson_motors">>},
-    {ok, {204, _, nil}} = hex_api_auth:test_key(?CONFIG, Params, <<"key">>),
+    {ok, {204, _, nil}} = hex_api_auth:test(?CONFIG, Params),
     ok.
 
 keys_test(_Config) ->

--- a/test/hex_api_SUITE.erl
+++ b/test/hex_api_SUITE.erl
@@ -17,7 +17,7 @@ suite() ->
     [{require, {ssl_certs, [test_pub, test_priv]}}].
 
 all() ->
-    [package_test, release_test, user_test, owner_test, keys_test].
+    [package_test, release_test, user_test, owner_test, keys_test, auth_test].
 
 package_test(_Config) ->
     {ok, {200, _, Package}} = hex_api_package:get(?CONFIG, <<"ecto">>),
@@ -51,6 +51,11 @@ user_test(_Config) ->
 owner_test(_Config) ->
     {ok, {200, _, [Owner | _]}} = hex_api_package_owner:list(?CONFIG, <<"decimal">>),
     <<"ericmj">> = maps:get(<<"username">>, Owner),
+    ok.
+
+auth_test(_Config) ->
+    Params = #{domain => <<"repository">>, resource => <<"gustafson_motors">>},
+    {ok, {204, _, nil}} = hex_api_auth:test_key(?CONFIG, Params, <<"key">>),
     ok.
 
 keys_test(_Config) ->

--- a/test/support/hex_http_test.erl
+++ b/test/support/hex_http_test.erl
@@ -97,6 +97,9 @@ fixture(get, <<?TEST_REPO_URL, _/binary>>, _, _) ->
 
 %% HTTP API
 
+fixture(get, <<?TEST_API_URL, "/auth?domain=repository&resource=gustafson_motors">>, _, _) ->
+    {ok, {204, api_headers(), term_to_binary(nil)}};
+
 fixture(get, <<?TEST_API_URL, "/users/josevalim">>, _, _) ->
     Payload = #{
         <<"username">> => <<"josevalim">>,


### PR DESCRIPTION
  - added hex_api_auth with test_key/3 function to test an authorization
  key against a given domain and resource using the hexpm api auth
  endpoint.