### PR TITLE
Fix type spec definitions and function specs

### DIFF
--- a/src/hex_api_organization_member.erl
+++ b/src/hex_api_organization_member.erl
@@ -65,7 +65,7 @@ get(Config, UsernameOrEmail) when is_map(Config) and is_binary(UsernameOrEmail) 
 %% '''
 %% @end
 -spec add(hex_core:config(), binary(), role()) -> hex_api:response().
-add(Config, UsernameOrEmail, Role) when is_map(Config) and is_binary(UsernameOrEmail) and is_binary(Role) ->
+add(Config, UsernameOrEmail, Role) when is_map(Config) and is_binary(UsernameOrEmail) and is_atom(Role) ->
     Path = hex_api:build_organization_path(Config, ["members"]),
     Params = #{<<"name">> => UsernameOrEmail, <<"role">> => Role},
     hex_api:post(Config, Path, Params).
@@ -86,7 +86,7 @@ add(Config, UsernameOrEmail, Role) when is_map(Config) and is_binary(UsernameOrE
 %% '''
 %% @end
 -spec update(hex_core:config(), binary(), role()) -> hex_api:response().
-update(Config, UsernameOrEmail, Role) when is_map(Config) and is_binary(UsernameOrEmail) and is_binary(Role) ->
+update(Config, UsernameOrEmail, Role) when is_map(Config) and is_binary(UsernameOrEmail) and is_atom(Role) ->
     Path = hex_api:build_organization_path(Config, ["members", UsernameOrEmail]),
     Params = #{<<"role">> => Role},
     hex_api:post(Config, Path, Params).

--- a/src/hex_core.erl
+++ b/src/hex_core.erl
@@ -59,6 +59,7 @@ J1i2xWFndWa6nfFnRxZmCStCOZWYYPlaxr+FZceFbpMwzTNs4g3d4tLNUcbKAIH4
     http_adapter => module(),
     http_etag => binary() | undefined,
     http_adapter_config => map(),
+    http_headers => map(),
     http_user_agent_fragment => binary(),
     repo_key => binary() | undefined,
     repo_name => binary(),
@@ -86,5 +87,6 @@ default_config() ->
         repo_url => <<"https://repo.hex.pm">>,
         repo_organization => undefined,
         repo_verify => true,
-        repo_verify_origin => true
+        repo_verify_origin => true,
+        http_headers => #{}
     }.

--- a/src/hex_erl_tar.hrl
+++ b/src/hex_erl_tar.hrl
@@ -22,13 +22,13 @@
 %% Options used when adding files to a tar archive.
 -record(add_opts, {
           read_info,          %% Fun to use for read file/link info.
-          chunk_size = 0,     %% For file reading when sending to sftp. 0=do not chunk
-          verbose = false,    %% Verbose on/off.
-          atime = undefined,
-          mtime = undefined,
-          ctime = undefined,
-          uid = 0,
-          gid = 0}).
+          chunk_size = 0 :: integer(),     %% For file reading when sending to sftp. 0=do not chunk
+          verbose = false :: boolean(),    %% Verbose on/off.
+          atime = undefined :: undefined | integer(),
+          mtime = undefined :: undefined | integer(),
+          ctime = undefined :: undefined | integer(),
+          uid = 0 :: integer(),
+          gid = 0 :: integer()}).
 -type add_opts() :: #add_opts{}.
 
 %% Options used when reading a tar archive.
@@ -41,9 +41,15 @@
           verbose = false :: boolean()}).      %% Verbose on/off.
 -type read_opts() :: #read_opts{}.
 
--type add_opt() :: dereference |
-                   verbose |
-                   {chunks, pos_integer()}.
+-type add_opt() ::   dereference
+                   | verbose
+                   | {chunks, pos_integer()}
+                   | {atime, integer()}
+                   | {mtime, integer()}
+                   | {ctime, integer()}
+                   | {uid, integer()}
+                   | {gid, integer()}.
+
 
 -type extract_opt() :: {cwd, string()} |
                        {files, [string()]} |

--- a/src/hex_registry.erl
+++ b/src/hex_registry.erl
@@ -91,7 +91,7 @@ decode_signed(Signed) ->
 
 %% @doc
 %% Decode message created with sign_protobuf/2 and verify it against public key.
--spec decode_and_verify_signed(map(), public_key()) -> {ok, binary()} | {error, term()}.
+-spec decode_and_verify_signed(binary(), public_key()) -> {ok, binary()} | {error, term()}.
 decode_and_verify_signed(Signed, PublicKey) ->
     #{payload := Payload, signature := Signature} = decode_signed(Signed),
     case verify(Payload, Signature, PublicKey) of

--- a/src/hex_tarball.erl
+++ b/src/hex_tarball.erl
@@ -18,7 +18,7 @@
 -type checksum() :: binary().
 -type contents() :: #{filename() => binary()}.
 -type filename() :: string().
--type files() :: [filename() | {filename(), filename()}] | contents().
+-type files() :: [{filename(), filename() | binary()}].
 -type metadata() :: map().
 -type tarball() :: binary().
 
@@ -43,7 +43,7 @@
 %%        inner_checksum => <<178,12,...>>}}
 %% '''
 %% @end
--spec create(metadata(), files()) -> {ok, {tarball(), checksum()}}.
+-spec create(metadata(), files()) -> {ok, {tarball(), checksum()}} | {error, term()}.
 create(Metadata, Files) ->
     MetadataBinary = encode_metadata(Metadata),
     ContentsTarball = create_memory_tarball(Files),


### PR DESCRIPTION
- Closes #79
- Add missing keys (atime, mtime, ctime, uid, and gid) to add_opt() type
        spec in hex_erl_tar header
- Change is_binary/1 guard to is_atom/1  on Role for hex_api_organization_member:add/3
- Add missing http_header k/v in hex_core:config() type spec
- Add default http_headers k/v in hex_core:default_config/0
- Remove last clause of v_type_sint32/2 that would never be hit per
        previous clauses in hex_pb_package.
- Uncomment missing key for Signed() in hex_pb_signed.erl
- Change first argument in decode_and_sign/2 spec from map to binary