### PR TITLE
hex_api: transition away from http_uri

### DIFF
--- a/src/hex_api.erl
+++ b/src/hex_api.erl
@@ -42,7 +42,7 @@ compose_query(Pairs) ->
     uri_string:compose_query(Pairs).
 -else.
 compose_query(Pairs) ->
-    String = join("&", lists:map(fun ({K, V}) -> K ++ "=" ++ V end, List)),
+    String = join("&", lists:map(fun ({K, V}) -> K ++ "=" ++ V end, Pairs)),
     http_uri:encode(String).
 -endif.
 


### PR DESCRIPTION
which has been deprecated in OTP 23 [master].

See erlang/rebar32195 and erlang/rebar3#2191 for the background.

I would be happy to move the `to_list/1` function to a utility module but there doesn't seem to be one at the moment. Rebar3 already has one, so I'm not sure if it's worth introducing a new module here.