### PR TITLE
Revert to using undefined vs nil

### DIFF
--- a/src/hex_api.erl
+++ b/src/hex_api.erl
@@ -16,7 +16,7 @@
 
 -export_type([body/0, response/0]).
 
--type response() :: {ok, {hex_http:status(), hex_http:headers(), body() | nil}} | {error, term()}.
+-type response() :: {ok, {hex_http:status(), hex_http:headers(), body() | undefined}} | {error, term()}.
 -type body() :: [body()] | #{binary() => body() | binary()}.
 
 get(Config, Path) ->
@@ -99,7 +99,7 @@ request(Config, Method, Path, Body) when is_binary(Path) and is_map(Config) ->
                     {ok, {Status, RespHeaders, binary_to_term(RespBody)}};
 
                 nomatch ->
-                    {ok, {Status, RespHeaders, nil}}
+                    {ok, {Status, RespHeaders, undefined}}
             end;
 
         Other ->

--- a/src/hex_api_auth.erl
+++ b/src/hex_api_auth.erl
@@ -9,7 +9,7 @@
 %% ```
 %% 1> Params = #{domain => <<"repository">>, resource => <<"gustafson_motors">>}.
 %% 2> hex_api_auth:test_key(hex_core:default_config(), Params).
-%% {ok,{204, ..., nil}}
+%% {ok,{204, ..., undefined}}
 %% '''
 %% @end
 -spec test(hex_core:config(), map()) -> hex_api:response().

--- a/src/hex_api_key.erl
+++ b/src/hex_api_key.erl
@@ -36,7 +36,7 @@
 %%           <<"user_agent">> => <<"hex_core/0.5.0 (httpc) (OTP/21) (erts/10.2)">>},
 %%     <<"name">> => <<"hex_core">>,
 %%     <<"permissions">> => [#{<<"domain">> => <<"api">>,<<"resource">> => <<"read">>}],
-%%     <<"revoked_at">> => nil,
+%%     <<"revoked_at">> => undefined,
 %%     <<"updated_at">> => <<"2019-02-27T14:38:54Z">>,
 %%     <<"url">> => <<"https://hex.pm/api/keys/test">>},
 %%     }]}}
@@ -63,7 +63,7 @@ list(Config) when is_map(Config) ->
 %%           <<"user_agent">> => <<"hex_core/0.5.0 (httpc) (OTP/21) (erts/10.2)">>},
 %%     <<"name">> => <<"hex_core">>,
 %%     <<"permissions">> => [#{<<"domain">> => <<"api">>,<<"resource">> => <<"read">>}],
-%%     <<"revoked_at">> => nil,
+%%     <<"revoked_at">> => undefined,
 %%     <<"updated_at">> => <<"2019-02-27T14:38:54Z">>,
 %%     <<"url">> => <<"https://hex.pm/api/keys/test">>},
 %%     }}}
@@ -90,7 +90,7 @@ get(Config, Name) when is_map(Config) and is_binary(Name) ->
 %%           <<"user_agent">> => <<"hex_core/0.5.0 (httpc) (OTP/21) (erts/10.2)">>},
 %%     <<"name">> => <<"hex_core">>,
 %%     <<"permissions">> => [#{<<"domain">> => <<"api">>,<<"resource">> => <<"read">>}],
-%%     <<"revoked_at">> => nil,
+%%     <<"revoked_at">> => undefined,
 %%     <<"updated_at">> => <<"2019-02-27T14:38:54Z">>,
 %%     <<"url">> => <<"https://hex.pm/api/keys/test">>},
 %%     }}}
@@ -118,7 +118,7 @@ add(Config, Name, Permissions) when is_map(Config) and is_binary(Name) and is_li
 %%           <<"user_agent">> => <<"hex_core/0.5.0 (httpc) (OTP/21) (erts/10.2)">>},
 %%     <<"name">> => <<"hex_core">>,
 %%     <<"permissions">> => [#{<<"domain">> => <<"api">>,<<"resource">> => <<"read">>}],
-%%     <<"revoked_at">> => nil,
+%%     <<"revoked_at">> => undefined,
 %%     <<"updated_at">> => <<"2019-02-27T14:38:54Z">>,
 %%     <<"url">> => <<"https://hex.pm/api/keys/test">>},
 %%     }}}
@@ -145,7 +145,7 @@ delete(Config, Name) when is_map(Config) and is_binary(Name) ->
 %%           <<"user_agent">> => <<"hex_core/0.5.0 (httpc) (OTP/21) (erts/10.2)">>},
 %%     <<"name">> => <<"hex_core">>,
 %%     <<"permissions">> => [#{<<"domain">> => <<"api">>,<<"resource">> => <<"read">>}],
-%%     <<"revoked_at">> => nil,
+%%     <<"revoked_at">> => undefined,
 %%     <<"updated_at">> => <<"2019-02-27T14:38:54Z">>,
 %%     <<"url">> => <<"https://hex.pm/api/keys/test">>},
 %%     }]}}

--- a/src/hex_api_organization_member.erl
+++ b/src/hex_api_organization_member.erl
@@ -98,7 +98,7 @@ update(Config, UsernameOrEmail, Role) when is_map(Config) and is_binary(Username
 %%
 %% ```
 %% > hex_api_organization_member:delete(hex_core:default_config()#{api_organization => <<"acme">>}, <<"user">>).
-%% {ok, {204, ..., nil}}
+%% {ok, {204, ..., undefined}}
 %% '''
 %% @end
 -spec delete(hex_core:config(), binary()) -> hex_api:response().

--- a/src/hex_api_package_owner.erl
+++ b/src/hex_api_package_owner.erl
@@ -87,7 +87,7 @@ when is_binary(PackageName) and is_binary(UsernameOrEmail) and is_map(Config) an
 %%
 %% ```
 %% > hex_api_package_owner:delete(hex_core:default_config(), <<"package">>, <<"user">>).
-%% {ok, {204, ..., nil}}
+%% {ok, {204, ..., undefined}}
 %% '''
 %% @end
 -spec delete(hex_core:config(), binary(), binary()) -> hex_api:response().

--- a/src/hex_api_release.erl
+++ b/src/hex_api_release.erl
@@ -33,8 +33,8 @@
 %%          #{<<"app">> => <<"package">>,
 %%            <<"build_tools">> => [<<"mix">>]},
 %%      <<"package_url">> => <<"https://hex.pm/api/packages/package">>,
-%%      <<"publisher">> => nil,<<"requirements">> => #{},
-%%      <<"retirement">> => nil,
+%%      <<"publisher">> => undefined,<<"requirements">> => #{},
+%%      <<"retirement">> => undefined,
 %%      <<"updated_at">> => <<"2019-07-28T21:12:11Z">>,
 %%      <<"url">> => <<"https://hex.pm/api/packages/package/releases/1.0.0">>,
 %%      <<"version">> => <<"1.0.0">>
@@ -63,8 +63,8 @@ get(Config, Name, Version) when is_map(Config) and is_binary(Name) and is_binary
 %%          #{<<"app">> => <<"package">>,
 %%            <<"build_tools">> => [<<"mix">>]},
 %%      <<"package_url">> => <<"https://hex.pm/api/packages/package">>,
-%%      <<"publisher">> => nil,<<"requirements">> => #{},
-%%      <<"retirement">> => nil,
+%%      <<"publisher">> => undefined,<<"requirements">> => #{},
+%%      <<"retirement">> => undefined,
 %%      <<"updated_at">> => <<"2019-07-28T21:12:11Z">>,
 %%      <<"url">> => <<"https://hex.pm/api/packages/package/releases/1.0.0">>,
 %%      <<"version">> => <<"1.0.0">>
@@ -86,7 +86,7 @@ publish(Config, Tarball) when is_map(Config) and is_binary(Tarball) ->
 %%
 %% ```
 %% > hex_api_release:delete(hex_core:default_config(), <<"package">>, <<"1.0.0">>).
-%% {ok, {204, ..., nil}}
+%% {ok, {204, ..., undefined}}
 %% '''
 %% @end
 -spec delete(hex_core:config(), binary(), binary()) -> hex_api:response().
@@ -101,7 +101,7 @@ delete(Config, Name, Version) when is_map(Config) and is_binary(Name) and is_bin
 %%
 %% ```
 %% > hex_api_release:retire(hex_core:default_config(), <<"package">>, <<"1.0.0">>, Params).
-%% {ok, {204, ..., nil}}
+%% {ok, {204, ..., undefined}}
 %% '''
 %% @end
 -spec retire(hex_core:config(), binary(), binary(), retirement_params()) -> hex_api:response().
@@ -116,7 +116,7 @@ retire(Config, Name, Version, Params) when is_map(Config) and is_binary(Name) an
 %%
 %% ```
 %% > hex_api_release:unretire(hex_core:default_config(), <<"package">>, <<"1.0.0">>).
-%% {ok, {204, ..., nil}}
+%% {ok, {204, ..., undefined}}
 %% '''
 %% @end
 -spec unretire(hex_core:config(), binary(), binary()) -> hex_api:response().

--- a/src/hex_api_user.erl
+++ b/src/hex_api_user.erl
@@ -65,7 +65,7 @@ when is_map(Config) and is_binary(Username) and is_binary(Password) and is_binar
 %%
 %% ```
 %% > hex_api_user:reset_password(hex_core:default_config(), <<"user">>).
-%% {ok, {204, ..., nil}}
+%% {ok, {204, ..., undefined}}
 %% '''
 %% @end
 -spec reset_password(hex_core:config(), binary()) -> hex_api:response().

--- a/test/hex_api_SUITE.erl
+++ b/test/hex_api_SUITE.erl
@@ -55,7 +55,7 @@ owner_test(_Config) ->
 
 auth_test(_Config) ->
     Params = #{domain => <<"repository">>, resource => <<"gustafson_motors">>},
-    {ok, {204, _, nil}} = hex_api_auth:test(?CONFIG, Params),
+    {ok, {204, _, undefined}} = hex_api_auth:test(?CONFIG, Params),
     ok.
 
 keys_test(_Config) ->

--- a/test/support/hex_http_test.erl
+++ b/test/support/hex_http_test.erl
@@ -98,7 +98,7 @@ fixture(get, <<?TEST_REPO_URL, _/binary>>, _, _) ->
 %% HTTP API
 
 fixture(get, <<?TEST_API_URL, "/auth?domain=repository&resource=gustafson_motors">>, _, _) ->
-    {ok, {204, api_headers(), term_to_binary(nil)}};
+    {ok, {204, api_headers(), term_to_binary(undefined)}};
 
 fixture(get, <<?TEST_API_URL, "/users/josevalim">>, _, _) ->
     Payload = #{


### PR DESCRIPTION
About 4 months ago instances of `undefined` were swapped out for `nil`. This happened as part of commit 1155a06b and ed71e5d6. The idiom in Erlang however is `undefined`. I assume this change was unintentional, but if it indeed was intentional we can just close out this PR. 