### PR TITLE
hex_taball to be able to unpack list of files

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ Unpack package tarball:
 {ok, #{outer_checksum := Checksum, contents := Contents, metadata := Metadata}} = hex_tarball:unpack(Tarball, memory).
 ```
 
+Or provide the list of files you want to extract from the tarball
+
+```erlang
+File = "dir/foo",
+{ok, #{outer_checksum := Checksum, contents := [{File, Content}], metadata := Metadata}} = hex_tarball:unpack(Tarball, [File], memory).
+```
+
+
 Remember to verify the outer tarball checksum against the registry checksum
 returned from `hex_repo:get_package(Config, Package)`.
 

--- a/test/hex_tarball_SUITE.erl
+++ b/test/hex_tarball_SUITE.erl
@@ -10,7 +10,7 @@ all() ->
     [disk_test, timestamps_and_permissions_test, symlinks_test,
      memory_test, build_tools_test, requirements_test,
      decode_metadata_test, unpack_error_handling_test,
-     docs_test
+     docs_test, unpack_all_files_test, unpack_list_of_files_test
     ].
 
 memory_test(_Config) ->
@@ -238,6 +238,24 @@ docs_test(Config) ->
 
     ok = hex_tarball:unpack_docs(Tarball, UnpackDir),
     {ok, <<"Docs">>} = file:read_file(filename:join(UnpackDir, "index.html")),
+
+    ok.
+
+unpack_all_files_test(_Config) ->
+    Metadata = #{<<"name">> => <<"foo">>, <<"version">> => <<"1.0.0">>},
+    Files = [{"foo", <<"">>},{"bar", <<"">>}],
+    {ok, #{tarball := Tarball}} = hex_tarball:create(Metadata, Files),
+
+    {ok, #{contents := Files}} = hex_tarball:unpack(Tarball, memory),
+
+    ok.
+
+unpack_list_of_files_test(_Config) ->
+    Metadata = #{<<"name">> => <<"foo">>, <<"version">> => <<"1.0.0">>},
+    ExpectedFile = {"foo", <<"">>},
+    {ok, #{tarball := Tarball}} = hex_tarball:create(Metadata, [ExpectedFile, {"bar", <<"">>}]),
+
+    {ok, #{contents := [ExpectedFile]}} = hex_tarball:unpack(Tarball, ["foo"], memory),
 
     ok.
 


### PR DESCRIPTION
I would like to be able to extract particular file from hex_tarball.. (needed for this https://github.com/hexpm/diff/pull/53)
Introduce second argument that might be a list of filenames and pass it down to `hex_erl_tar` along with the list of options in tuple `{files, ListOfFiles}` or an atom `all_files` (so that we could default `unpack/2` to it)
```erlang
unpack(Tarball, Output) ->
  unpack(Tarball, all_files, Output, hex_core:default_config()).
```

@ericmj do you think it's possible to move recently introduced last config param from `hex_tarball:unpack/3` to `hex_param:unpack/4` while master is not released yet?
_Sorry for this late PR (should have been done earlier)_