### PR TITLE
Include CHANGELOG.md in the Hex package

### DIFF
--- a/src/hex_core.app.src
+++ b/src/hex_core.app.src
@@ -4,6 +4,7 @@
   {registered, []},
   {applications, [kernel, stdlib]},
   {licenses, ["Apache-2.0"]},
+  {include_files, ["CHANGELOG.md"]},
   {links, [
     {"GitHub", "https://github.com/hexpm/hex_core"},
     {"Hex specifications", "https://github.com/hexpm/specifications"}


### PR DESCRIPTION
- closes #98 
- use include_files app option to add CHANGELOG.md to hex_core package release