### PR TITLE
Deprecate `http_adapter_config` to include it in `http_adapter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ HTTP client configuration can be overridden as follows:
 
 ```erlang
 Config = maps:merge(hex_core:default_config(), #{
-  http_adapter => my_hackney_adapter,
+  http_adapter => {my_hackney_adapter, my_hackney_adapter_config},
   http_user_agent_fragment => <<"(my_app/0.1.0) (hackney/1.12.1) ">>
 }),
 hex_repo:get_names(Config).
@@ -128,7 +128,7 @@ request(Method, URI, ReqHeaders) ->
     %% ...
 ```
 
-See the [`hex_core` module](hex_core.html) for more information about the configuration.
+See the [`hex_core` module](src/hex_core.erl) for more information about the configuration.
 
 ## Wrapper Module
 

--- a/src/hex_core.erl
+++ b/src/hex_core.erl
@@ -16,11 +16,10 @@
 %% * `api_repository' - Name of the repository endpoint in the API, this should
 %%   for example be set when accessing packages from a specific repository.
 %% * `api_url' - URL to the HTTP API (default: `https://hex.pm/api').
-%% * `http_adapter' - Callback module used for HTTP requests, see [`hex_http'](hex_http.html)
-%%   (default: `hex_http_httpc').
+%% * `http_adapter' - A tuple of a callback module used for HTTP requests, see [`hex_http'](hex_http.html)
+%%   (default: `hex_http_httpc') and the configuration to pass to the HTTP adapter.
 %% * `http_etag' - Sets the `if-none-match' HTTP header with the given value to do a
 %%   conditional HTTP request.
-%% * `http_adapter_config' - Configuration to pass to the HTTP adapter.
 %% * `http_user_agent_fragment' - Will be appended to the `user-agent` HTTP header (default: `(httpc)').
 %% * `repo_key' - Authentication key used when accessing the repository.
 %% * `repo_name' - Name of the repository, used for verifying the repository signature
@@ -56,9 +55,8 @@ J1i2xWFndWa6nfFnRxZmCStCOZWYYPlaxr+FZceFbpMwzTNs4g3d4tLNUcbKAIH4
     api_organization => binary() | undefined,
     api_repository => binary() | undefined,
     api_url => binary(),
-    http_adapter => module(),
+    http_adapter => {module(), map()},
     http_etag => binary() | undefined,
-    http_adapter_config => map(),
     http_headers => map(),
     http_user_agent_fragment => binary(),
     repo_key => binary() | undefined,
@@ -79,8 +77,7 @@ default_config() ->
         api_organization => undefined,
         api_repository => undefined,
         api_url => <<"https://hex.pm/api">>,
-        http_adapter => hex_http_httpc,
-        http_adapter_config => #{profile => default},
+        http_adapter => {hex_http_httpc, #{profile => default}},
         http_etag => undefined,
         http_headers => #{},
         http_user_agent_fragment => <<"(httpc)">>,

--- a/src/hex_http.erl
+++ b/src/hex_http.erl
@@ -18,10 +18,9 @@
 -spec request(hex_core:config(), method(), URI :: binary(), headers(), body()) ->
     {ok, {status(), headers(), binary()}} | {error, term()}.
 request(Config, Method, URI, Headers, Body) when is_binary(URI) and is_map(Headers) ->
-    Adapter = maps:get(http_adapter, Config),
+    {Adapter, AdapterConfig} = maps:get(http_adapter, Config, {hex_http_httpc, #{}}),
     UserAgentFragment = maps:get(http_user_agent_fragment, Config),
     Headers2 = put_new(<<"user-agent">>, user_agent(UserAgentFragment), Headers),
-    AdapterConfig = maps:get(http_adapter_config, Config, #{}),
     Adapter:request(Method, URI, Headers2, Body, AdapterConfig).
 
 user_agent(UserAgentFragment) ->

--- a/src/hex_http.erl
+++ b/src/hex_http.erl
@@ -18,7 +18,16 @@
 -spec request(hex_core:config(), method(), URI :: binary(), headers(), body()) ->
     {ok, {status(), headers(), binary()}} | {error, term()}.
 request(Config, Method, URI, Headers, Body) when is_binary(URI) and is_map(Headers) ->
-    {Adapter, AdapterConfig} = maps:get(http_adapter, Config, {hex_http_httpc, #{}}),
+    {Adapter, AdapterConfig} = case maps:get(http_adapter, Config, {hex_http_httpc, #{}}) of
+        {Adapter0, AdapterConfig0} ->
+            {Adapter0, AdapterConfig0};
+        %% TODO: remove in v0.9
+        Adapter0 when is_atom(Adapter0) ->
+            AdapterConfig0 = maps:get(http_adapter_config, Config, #{}),
+            io:format("[hex_http] setting #{http_adapter => Module, http_adapter_config => Map} "
+                      "is deprecated in favour of #{http_adapter => {Module, Map}}~n"),
+            {Adapter0, AdapterConfig0}
+    end,
     UserAgentFragment = maps:get(http_user_agent_fragment, Config),
     Headers2 = put_new(<<"user-agent">>, user_agent(UserAgentFragment), Headers),
     Adapter:request(Method, URI, Headers2, Body, AdapterConfig).

--- a/src/hex_repo.erl
+++ b/src/hex_repo.erl
@@ -92,7 +92,7 @@ get_package(Config, Name) when is_binary(Name) and is_map(Config) ->
 %% Examples:
 %%
 %% ```
-%% > {ok, {200, _, Tarball}} = hex_repo:get_tarball(<<"package1">>, <<"1.0.0">>, hex_core:default_config()),
+%% > {ok, {200, _, Tarball}} = hex_repo:get_tarball(hex_core:default_config(), <<"package1">>, <<"1.0.0">>),
 %% > {ok, #{metadata := Metadata}} = hex_tarball:unpack(Tarball, memory).
 %% '''
 %% @end

--- a/test/hex_api_SUITE.erl
+++ b/test/hex_api_SUITE.erl
@@ -5,8 +5,10 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 
+-define(DEFAULT_HTTP_ADAPTER_CONFIG, #{profile => default}).
+
 -define(CONFIG, (hex_core:default_config())#{
-    http_adapter => hex_http_test,
+    http_adapter => {hex_http_test, ?DEFAULT_HTTP_ADAPTER_CONFIG},
     http_user_agent_fragment => <<"(test)">>,
     api_url => <<"https://api.test">>,
     api_key => <<"dummy">>

--- a/test/hex_repo_SUITE.erl
+++ b/test/hex_repo_SUITE.erl
@@ -5,8 +5,10 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 
+-define(DEFAULT_HTTP_ADAPTER_CONFIG, #{profile => default}).
+
 -define(CONFIG, (hex_core:default_config())#{
-    http_adapter => hex_http_test,
+    http_adapter => {hex_http_test, ?DEFAULT_HTTP_ADAPTER_CONFIG},
     http_user_agent_fragment => <<"(test)">>,
     repo_url => <<"https://repo.test">>,
     repo_public_key => ct:get_config({ssl_certs, test_pub})


### PR DESCRIPTION
This commit deprecates the old `hex_core`configuration of
`#{http_adapter => Mod, http_adapter_config => Map}` by replacing it with
`#{http_adapter => {Mod, Map}}`.

It also fixes a broken link in the README.md, which was also updated
to these changes.

Should close #78.