### PR TITLE
Add WITH_STACKTRACE macro for OTP >= 24 compatibility

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,7 @@
 {erl_opts, [
     debug_info,
-    {platform_define, "^19", 'OTP_19'}
+    {platform_define, "^19", 'OTP_19'},
+    {platform_define, "^(R|1|20)", fun_stacktrace}
 ]}.
 {gpb_opts, [
     {i, "proto"},

--- a/src/hex_core.hrl
+++ b/src/hex_core.hrl
@@ -1,1 +1,7 @@
 -define(HEX_CORE_VERSION, "0.7.0").
+
+-ifdef(fun_stacktrace).
+-define(WITH_STACKTRACE(T, R, S), T:R -> S = erlang:get_stacktrace(),).
+-else.
+-define(WITH_STACKTRACE(T, R, S), T:R:S ->).
+-endif.

--- a/src/hex_pb_names.erl
+++ b/src/hex_pb_names.erl
@@ -22,6 +22,7 @@
 -export([get_package_name/0]).
 -export([gpb_version_as_string/0, gpb_version_as_list/0]).
 
+-include("hex_core.hrl").
 
 %% enumerated types
 
@@ -198,20 +199,24 @@ decode_msg(Bin, MsgName, Opts) when is_binary(Bin) ->
 -ifdef('OTP_RELEASE').
 decode_msg_1_catch(Bin, MsgName, TrUserData) ->
     try decode_msg_2_doit(MsgName, Bin, TrUserData)
-    catch Class:Reason:StackTrace -> error({gpb_error,{decoding_failure, {Bin, MsgName, {Class, Reason, StackTrace}}}})
+    catch
+         ?WITH_STACKTRACE(Class,Reason,StackTrace)
+           error({gpb_error,{decoding_failure, {Bin, MsgName, {Class, Reason, StackTrace}}}})
     end.
 -else.
 -ifdef('GPB_PATTERN_STACK').
 decode_msg_1_catch(Bin, MsgName, TrUserData) ->
     try decode_msg_2_doit(MsgName, Bin, TrUserData)
-    catch Class:Reason:StackTrace -> error({gpb_error,{decoding_failure, {Bin, MsgName, {Class, Reason, StackTrace}}}})
+    catch
+        ?WITH_STACKTRACE(Class, Reason, StackTrace)
+          error({gpb_error,{decoding_failure, {Bin, MsgName, {Class, Reason, StackTrace}}}})
     end.
 -else.
 decode_msg_1_catch(Bin, MsgName, TrUserData) ->
     try decode_msg_2_doit(MsgName, Bin, TrUserData)
-    catch Class:Reason ->
-        StackTrace = erlang:get_stacktrace(),
-        error({gpb_error,{decoding_failure, {Bin, MsgName, {Class, Reason, StackTrace}}}})
+    catch
+        ?WITH_STACKTRACE(Class,Reason,StackTrace)
+          error({gpb_error,{decoding_failure, {Bin, MsgName, {Class, Reason, StackTrace}}}})
     end.
 -endif.
 

--- a/src/hex_pb_package.erl
+++ b/src/hex_pb_package.erl
@@ -23,6 +23,7 @@
 -export([get_package_name/0]).
 -export([gpb_version_as_string/0, gpb_version_as_list/0]).
 
+-include("hex_core.hrl").
 
 %% enumerated types
 -type 'RetirementReason'() :: 'RETIRED_OTHER' | 'RETIRED_INVALID' | 'RETIRED_SECURITY' | 'RETIRED_DEPRECATED' | 'RETIRED_RENAMED'.
@@ -275,21 +276,28 @@ decode_msg(Bin, MsgName, Opts) when is_binary(Bin) ->
 
 -ifdef('OTP_RELEASE').
 decode_msg_1_catch(Bin, MsgName, TrUserData) ->
-    try decode_msg_2_doit(MsgName, Bin, TrUserData)
-    catch Class:Reason:StackTrace -> error({gpb_error,{decoding_failure, {Bin, MsgName, {Class, Reason, StackTrace}}}})
+    try
+        decode_msg_2_doit(MsgName, Bin, TrUserData)
+    catch
+        ?WITH_STACKTRACE(Class,Reason,StackTrace)
+          error({gpb_error,{decoding_failure, {Bin, MsgName, {Class, Reason, StackTrace}}}})
     end.
 -else.
 -ifdef('GPB_PATTERN_STACK').
 decode_msg_1_catch(Bin, MsgName, TrUserData) ->
-    try decode_msg_2_doit(MsgName, Bin, TrUserData)
-    catch Class:Reason:StackTrace -> error({gpb_error,{decoding_failure, {Bin, MsgName, {Class, Reason, StackTrace}}}})
+    try
+        decode_msg_2_doit(MsgName, Bin, TrUserData)
+    catch
+        ?WITH_STACKTRACE(Class,Reason,StackTrace)
+          error({gpb_error,{decoding_failure, {Bin, MsgName, {Class, Reason, StackTrace}}}})
     end.
 -else.
 decode_msg_1_catch(Bin, MsgName, TrUserData) ->
-    try decode_msg_2_doit(MsgName, Bin, TrUserData)
-    catch Class:Reason ->
-        StackTrace = erlang:get_stacktrace(),
-        error({gpb_error,{decoding_failure, {Bin, MsgName, {Class, Reason, StackTrace}}}})
+    try
+        decode_msg_2_doit(MsgName, Bin, TrUserData)
+    catch
+        ?WITH_STACKTRACE(Class,Reason,StackTrace)
+          error({gpb_error,{decoding_failure, {Bin, MsgName, {Class, Reason, StackTrace}}}})
     end.
 -endif.
 

--- a/src/hex_pb_signed.erl
+++ b/src/hex_pb_signed.erl
@@ -22,6 +22,7 @@
 -export([get_package_name/0]).
 -export([gpb_version_as_string/0, gpb_version_as_list/0]).
 
+-include("hex_core.hrl").
 
 %% enumerated types
 
@@ -170,20 +171,24 @@ decode_msg(Bin, MsgName, Opts) when is_binary(Bin) ->
 -ifdef('OTP_RELEASE').
 decode_msg_1_catch(Bin, MsgName, TrUserData) ->
     try decode_msg_2_doit(MsgName, Bin, TrUserData)
-    catch Class:Reason:StackTrace -> error({gpb_error,{decoding_failure, {Bin, MsgName, {Class, Reason, StackTrace}}}})
+    catch
+        ?WITH_STACKTRACE(Class,Reason,StackTrace)
+          error({gpb_error,{decoding_failure, {Bin, MsgName, {Class, Reason, StackTrace}}}})
     end.
 -else.
 -ifdef('GPB_PATTERN_STACK').
 decode_msg_1_catch(Bin, MsgName, TrUserData) ->
     try decode_msg_2_doit(MsgName, Bin, TrUserData)
-    catch Class:Reason:StackTrace -> error({gpb_error,{decoding_failure, {Bin, MsgName, {Class, Reason, StackTrace}}}})
+    catch
+        ?WITH_STACKTRACE(Class,Reason,StackTrace)
+          error({gpb_error,{decoding_failure, {Bin, MsgName, {Class, Reason, StackTrace}}}})
     end.
 -else.
 decode_msg_1_catch(Bin, MsgName, TrUserData) ->
     try decode_msg_2_doit(MsgName, Bin, TrUserData)
-    catch Class:Reason ->
-        StackTrace = erlang:get_stacktrace(),
-        error({gpb_error,{decoding_failure, {Bin, MsgName, {Class, Reason, StackTrace}}}})
+    catch
+        ?WITH_STACKTRACE(Class,Reason,StackTrace)
+          error({gpb_error,{decoding_failure, {Bin, MsgName, {Class, Reason, StackTrace}}}})
     end.
 -endif.
 

--- a/src/hex_pb_versions.erl
+++ b/src/hex_pb_versions.erl
@@ -22,6 +22,7 @@
 -export([get_package_name/0]).
 -export([gpb_version_as_string/0, gpb_version_as_list/0]).
 
+-include("hex_core.hrl").
 
 %% enumerated types
 
@@ -241,21 +242,28 @@ decode_msg(Bin, MsgName, Opts) when is_binary(Bin) ->
 
 -ifdef('OTP_RELEASE').
 decode_msg_1_catch(Bin, MsgName, TrUserData) ->
-    try decode_msg_2_doit(MsgName, Bin, TrUserData)
-    catch Class:Reason:StackTrace -> error({gpb_error,{decoding_failure, {Bin, MsgName, {Class, Reason, StackTrace}}}})
+    try
+        decode_msg_2_doit(MsgName, Bin, TrUserData)
+    catch
+        ?WITH_STACKTRACE(Class,Reason,StackTrace)
+          error({gpb_error,{decoding_failure, {Bin, MsgName, {Class, Reason, StackTrace}}}})
     end.
 -else.
 -ifdef('GPB_PATTERN_STACK').
 decode_msg_1_catch(Bin, MsgName, TrUserData) ->
-    try decode_msg_2_doit(MsgName, Bin, TrUserData)
-    catch Class:Reason:StackTrace -> error({gpb_error,{decoding_failure, {Bin, MsgName, {Class, Reason, StackTrace}}}})
+    try
+        decode_msg_2_doit(MsgName, Bin, TrUserData)
+    catch
+        ?WITH_STACKTRACE(Class,Reason,StackTrace)
+          error({gpb_error,{decoding_failure, {Bin, MsgName, {Class, Reason, StackTrace}}}})
     end.
 -else.
 decode_msg_1_catch(Bin, MsgName, TrUserData) ->
-    try decode_msg_2_doit(MsgName, Bin, TrUserData)
-    catch Class:Reason ->
-        StackTrace = erlang:get_stacktrace(),
-        error({gpb_error,{decoding_failure, {Bin, MsgName, {Class, Reason, StackTrace}}}})
+    try
+        decode_msg_2_doit(MsgName, Bin, TrUserData)
+    catch
+        ?WITH_STACKTRACE(Class,Reason,StackTrace)
+          error({gpb_error,{decoding_failure, {Bin, MsgName, {Class, Reason, StackTrace}}}})
     end.
 -endif.
 


### PR DESCRIPTION
- Added WITH_STACKTRACE macro havested from rebar3
(https://github.com/erlang/rebar3/blob/a42f515739f8b103d9732409405bd3c69075b63c/src/rebar.hrl#L62)

This will silence warnings in OTP versions >= 21 and supports OTP >= 24. 