### PR TITLE
Prevent wrong indentation on documentation generation

### DIFF
--- a/doc/tpl.html
+++ b/doc/tpl.html
@@ -46,7 +46,7 @@
 
     <div id="main" class="main">
       <div class="content" style="max-width: 860px;">
-        $body$
+$body$
       </div>
     </div>
   </div>


### PR DESCRIPTION
Closes #108.

It seems `pandoc` will generate the output indenting it by the same indentation as `$body$`, which is why it was generating an extra 8 white spaces, thus shifting everything to the right.