### PR TITLE
fix arity in hex_http:request/5 example pseudocode

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,9 @@ hex_repo:get_names(Config).
 %% my_hackney_adapter.erl
 -module(my_hackney_adapter).
 -behaviour(hex_http).
--exports([request/3]).
+-exports([request/5]).
 
-request(Method, URI, ReqHeaders) ->
+request(Method, URI, ReqHeaders, Body, AdapterConfig) ->
     %% ...
 ```
 


### PR DESCRIPTION
:wave: hello!

I was reading through the readme and spotted that the pseudocode for the hex_http:request/5 hackney implementation was implementing request/3 instead of request/5.

It looks like this callback was originally arity-3 but was upped to arity-4 (adding Body) in [this commit](https://github.com/hexpm/hex_core/commit/6d1cdbfe9e845c83febb0dc7f9e5267bb60b5313#diff-bd7a180f9366bd83c314b0226b8251d03775e042d9fa82b58ee2116da204d993R13) and later upped to arity-5 (adding AdapterConfig) in [this commit](https://github.com/hexpm/hex_core/commit/0f07a9454ab97595b6efd5d8fc21dd1a881bfe8d#diff-bd7a180f9366bd83c314b0226b8251d03775e042d9fa82b58ee2116da204d993R14).

