### PR TITLE
Get Repository Name

### DIFF
--- a/src/hex_registry.erl
+++ b/src/hex_registry.erl
@@ -80,13 +80,13 @@ encode_versions(Versions) ->
 
 %% @private
 decode_versions(Payload, no_verify) ->
-    #{packages := Packages} = hex_pb_versions:decode_msg(Payload, 'Versions'),
-    {ok, Packages};
+    #{repository := Repository, packages := Packages} = hex_pb_versions:decode_msg(Payload, 'Versions'),
+    {ok, #{repository => Repository, packages => Packages}};
 
 decode_versions(Payload, Repository) ->
     case hex_pb_versions:decode_msg(Payload, 'Versions') of
         #{repository := Repository, packages := Packages} ->
-            {ok, Packages};
+            {ok, #{repository => Repository, packages => Packages}};
         _ ->
             {error, unverified}
     end.
@@ -111,13 +111,13 @@ encode_package(Package) ->
 
 %% @private
 decode_package(Payload, no_verify, no_verify) ->
-    #{releases := Releases} = hex_pb_package:decode_msg(Payload, 'Package'),
-    {ok, Releases};
+    #{repository := Repository, name := Package, releases := Releases} = hex_pb_package:decode_msg(Payload, 'Package'),
+    {ok, #{repository => Repository, name => Package, releases => Releases}};
 
 decode_package(Payload, Repository, Package) ->
     case hex_pb_package:decode_msg(Payload, 'Package') of
         #{repository := Repository, name := Package, releases := Releases} ->
-            {ok, Releases};
+            {ok, #{repository => Repository, name => Package, releases => Releases}};
         _ ->
             {error, unverified}
     end.

--- a/src/hex_registry.erl
+++ b/src/hex_registry.erl
@@ -6,6 +6,7 @@
     decode_names/2,
     build_names/2,
     unpack_names/3,
+    get_repository_name/2,
     encode_versions/1,
     decode_versions/2,
     build_versions/2,
@@ -59,6 +60,19 @@ decode_names(Payload, Repository) ->
         _ ->
             {error, unverified}
     end.
+
+%% @doc
+%% Get the encoded repository name.
+get_repository_name(Payload, PublicKey) ->
+  case decode_and_verify_signed(zlib:gunzip(Payload), PublicKey) of
+    {ok, Names} -> decode_repository_name(Names);
+    Other -> Other
+  end.
+
+%% @private
+decode_repository_name(Payload) ->
+  #{repository := Repository} = hex_pb_names:decode_msg(Payload, 'Names'),
+  {ok, Repository}.
 
 %% @doc
 %% Builds versions resource.

--- a/src/hex_registry.erl
+++ b/src/hex_registry.erl
@@ -49,13 +49,12 @@ encode_names(Names) ->
 
 %% @private
 decode_names(Payload, no_verify) ->
-    #{repository := Repository, packages := Packages} = hex_pb_names:decode_msg(Payload, 'Names'),
-    {ok, #{repository => Repository, packages => Packages}};
+    {ok, hex_pb_names:decode_msg(Payload, 'Names')};
 
 decode_names(Payload, Repository) ->
     case hex_pb_names:decode_msg(Payload, 'Names') of
-        #{repository := Repository, packages := Packages} ->
-            {ok, #{repository => Repository, packages => Packages}};
+        #{repository := Repository, packages := _Packages} = Result ->
+            {ok, Result};
         _ ->
             {error, unverified}
     end.
@@ -80,13 +79,12 @@ encode_versions(Versions) ->
 
 %% @private
 decode_versions(Payload, no_verify) ->
-    #{repository := Repository, packages := Packages} = hex_pb_versions:decode_msg(Payload, 'Versions'),
-    {ok, #{repository => Repository, packages => Packages}};
+    {ok, hex_pb_versions:decode_msg(Payload, 'Versions')};
 
 decode_versions(Payload, Repository) ->
     case hex_pb_versions:decode_msg(Payload, 'Versions') of
-        #{repository := Repository, packages := Packages} ->
-            {ok, #{repository => Repository, packages => Packages}};
+        #{repository := Repository, packages := _Packages} = Result ->
+            {ok, Result};
         _ ->
             {error, unverified}
     end.
@@ -111,13 +109,12 @@ encode_package(Package) ->
 
 %% @private
 decode_package(Payload, no_verify, no_verify) ->
-    #{repository := Repository, name := Package, releases := Releases} = hex_pb_package:decode_msg(Payload, 'Package'),
-    {ok, #{repository => Repository, name => Package, releases => Releases}};
+    {ok, hex_pb_package:decode_msg(Payload, 'Package')};
 
 decode_package(Payload, Repository, Package) ->
     case hex_pb_package:decode_msg(Payload, 'Package') of
-        #{repository := Repository, name := Package, releases := Releases} ->
-            {ok, #{repository => Repository, name => Package, releases => Releases}};
+        #{repository := Repository, name := Package, releases := _Releases} = Result ->
+            {ok, Result};
         _ ->
             {error, unverified}
     end.

--- a/src/hex_registry.erl
+++ b/src/hex_registry.erl
@@ -6,7 +6,6 @@
     decode_names/2,
     build_names/2,
     unpack_names/3,
-    get_repository_name/2,
     encode_versions/1,
     decode_versions/2,
     build_versions/2,
@@ -50,29 +49,16 @@ encode_names(Names) ->
 
 %% @private
 decode_names(Payload, no_verify) ->
-    #{packages := Packages} = hex_pb_names:decode_msg(Payload, 'Names'),
-    {ok, Packages};
+    #{repository := Repository, packages := Packages} = hex_pb_names:decode_msg(Payload, 'Names'),
+    {ok, #{repository => Repository, packages => Packages}};
 
 decode_names(Payload, Repository) ->
     case hex_pb_names:decode_msg(Payload, 'Names') of
         #{repository := Repository, packages := Packages} ->
-            {ok, Packages};
+            {ok, #{repository => Repository, packages => Packages}};
         _ ->
             {error, unverified}
     end.
-
-%% @doc
-%% Get the encoded repository name.
-get_repository_name(Payload, PublicKey) ->
-  case decode_and_verify_signed(zlib:gunzip(Payload), PublicKey) of
-    {ok, Names} -> decode_repository_name(Names);
-    Other -> Other
-  end.
-
-%% @private
-decode_repository_name(Payload) ->
-  #{repository := Repository} = hex_pb_names:decode_msg(Payload, 'Names'),
-  {ok, Repository}.
 
 %% @doc
 %% Builds versions resource.

--- a/src/hex_repo.erl
+++ b/src/hex_repo.erl
@@ -57,10 +57,12 @@ get_names(Config) when is_map(Config) ->
 get_versions(Config) when is_map(Config) ->
     Verify = maps:get(repo_verify_origin, Config, true),
     Decoder = fun(Data) ->
-        case Verify of
-            true -> hex_registry:decode_versions(Data, repo_name(Config));
-            false -> hex_registry:decode_versions(Data, no_verify)
-        end
+        {ok, #{packages := Packages}} =
+            case Verify of
+                true -> hex_registry:decode_versions(Data, repo_name(Config));
+                false -> hex_registry:decode_versions(Data, no_verify)
+            end,
+        {ok, Packages}
     end,
     get_protobuf(Config, <<"versions">>, Decoder).
 
@@ -83,10 +85,12 @@ get_versions(Config) when is_map(Config) ->
 get_package(Config, Name) when is_binary(Name) and is_map(Config) ->
     Verify = maps:get(repo_verify_origin, Config, true),
     Decoder = fun(Data) ->
-        case Verify of
-            true -> hex_registry:decode_package(Data, repo_name(Config), Name);
-            false -> hex_registry:decode_package(Data, no_verify, no_verify)
-        end
+        {ok, #{releases := Releases}} =
+            case Verify of
+                true -> hex_registry:decode_package(Data, repo_name(Config), Name);
+                false -> hex_registry:decode_package(Data, no_verify, no_verify)
+            end,
+        {ok, Releases}
     end,
     get_protobuf(Config, <<"packages/", Name/binary>>, Decoder).
 

--- a/src/hex_repo.erl
+++ b/src/hex_repo.erl
@@ -29,10 +29,12 @@
 get_names(Config) when is_map(Config) ->
     Verify = maps:get(repo_verify_origin, Config, true),
     Decoder = fun(Data) ->
-        case Verify of
-            true -> hex_registry:decode_names(Data, repo_name(Config));
-            false -> hex_registry:decode_names(Data, no_verify)
-        end
+        {ok, #{packages := Packages}} =
+            case Verify of
+                true -> hex_registry:decode_names(Data, repo_name(Config));
+                false -> hex_registry:decode_names(Data, no_verify)
+            end,
+        {ok, Packages}
     end,
     get_protobuf(Config, <<"names">>, Decoder).
 

--- a/test/hex_registry_SUITE.erl
+++ b/test/hex_registry_SUITE.erl
@@ -49,8 +49,8 @@ versions_test(_Config) ->
         packages => Packages
     },
     Payload = hex_registry:build_versions(Versions, TestPrivateKey),
-    ?assertMatch({ok, Packages}, hex_registry:unpack_versions(Payload, <<"hexpm">>, TestPublicKey)),
-    ?assertMatch({ok, Packages}, hex_registry:unpack_versions(Payload, no_verify, TestPublicKey)),
+    ?assertMatch({ok, Versions}, hex_registry:unpack_versions(Payload, <<"hexpm">>, TestPublicKey)),
+    ?assertMatch({ok, Versions}, hex_registry:unpack_versions(Payload, no_verify, TestPublicKey)),
     ?assertMatch({error, unverified}, hex_registry:unpack_versions(Payload, <<"other_repo">>, TestPublicKey)),
     ok.
 
@@ -90,8 +90,8 @@ package_test(_Config) ->
         releases => Releases
     },
     Payload = hex_registry:build_package(Package, TestPrivateKey),
-    ?assertMatch({ok, Releases}, hex_registry:unpack_package(Payload, <<"hexpm">>, <<"foobar">>, TestPublicKey)),
-    ?assertMatch({ok, Releases}, hex_registry:unpack_package(Payload, no_verify, no_verify, TestPublicKey)),
+    ?assertMatch({ok, Package}, hex_registry:unpack_package(Payload, <<"hexpm">>, <<"foobar">>, TestPublicKey)),
+    ?assertMatch({ok, Package}, hex_registry:unpack_package(Payload, no_verify, no_verify, TestPublicKey)),
     ?assertMatch({error, unverified}, hex_registry:unpack_package(Payload, <<"other_repo">>, <<"foobar">>, TestPublicKey)),
     ?assertMatch({error, unverified}, hex_registry:unpack_package(Payload, <<"hexpm">>, <<"other_package">>, TestPublicKey)),
     ok.

--- a/test/hex_registry_SUITE.erl
+++ b/test/hex_registry_SUITE.erl
@@ -27,6 +27,8 @@ names_test(_Config) ->
     ?assertMatch({ok, Packages}, hex_registry:unpack_names(Payload, <<"hexpm">>, TestPublicKey)),
     ?assertMatch({ok, Packages}, hex_registry:unpack_names(Payload, no_verify, TestPublicKey)),
     ?assertMatch({error, unverified}, hex_registry:unpack_names(Payload, <<"other_repo">>, TestPublicKey)),
+    DecodedName = hex_registry:get_repository_name(Payload, TestPublicKey),
+    ?assertMatch({ok, <<"hexpm">>}, DecodedName),
     ok.
 
 versions_test(_Config) ->

--- a/test/hex_registry_SUITE.erl
+++ b/test/hex_registry_SUITE.erl
@@ -24,11 +24,9 @@ names_test(_Config) ->
         packages => Packages
     },
     Payload = hex_registry:build_names(Names, TestPrivateKey),
-    ?assertMatch({ok, Packages}, hex_registry:unpack_names(Payload, <<"hexpm">>, TestPublicKey)),
-    ?assertMatch({ok, Packages}, hex_registry:unpack_names(Payload, no_verify, TestPublicKey)),
+    ?assertMatch({ok, Names}, hex_registry:unpack_names(Payload, <<"hexpm">>, TestPublicKey)),
+    ?assertMatch({ok, Names}, hex_registry:unpack_names(Payload, no_verify, TestPublicKey)),
     ?assertMatch({error, unverified}, hex_registry:unpack_names(Payload, <<"other_repo">>, TestPublicKey)),
-    DecodedName = hex_registry:get_repository_name(Payload, TestPublicKey),
-    ?assertMatch({ok, <<"hexpm">>}, DecodedName),
     ok.
 
 versions_test(_Config) ->
@@ -109,7 +107,7 @@ signed_test(_Config) ->
     Signed = hex_registry:sign_protobuf(Payload, TestPrivateKey),
     #{payload := Payload} = hex_registry:decode_signed(Signed),
     {ok, Payload} = hex_registry:decode_and_verify_signed(Signed, TestPublicKey),
-    {ok, []} = hex_registry:decode_names(Payload, <<"hexpm">>),
+    {ok, #{packages := []}} = hex_registry:decode_names(Payload, <<"hexpm">>),
 
     {error, bad_key} = hex_registry:decode_and_verify_signed(Signed, <<"bad">>),
 


### PR DESCRIPTION
This PR is related to hexpm/hex#931.

~In order to enable the modification of hex repositories without the need for a `--name` flag, this change adds `hex_registry:get_repository_name/2`.~

After further discussion, this PR makes a breaking change to the return type of several registry-reading functions to return additional information that may be useful in the future.