### PR TITLE
[#136] Bump default tarball_max_size from 8 MiB to 16 MiB

### DIFF
--- a/src/hex_core.erl
+++ b/src/hex_core.erl
@@ -103,5 +103,5 @@ default_config() ->
         repo_verify => true,
         repo_verify_origin => true,
         tarball_max_size => 16 * 1024 * 1024,
-        tarball_max_uncompressed_size => 64 * 1024 * 1024
+        tarball_max_uncompressed_size => 128 * 1024 * 1024
     }.

--- a/src/hex_core.erl
+++ b/src/hex_core.erl
@@ -102,6 +102,6 @@ default_config() ->
         repo_organization => undefined,
         repo_verify => true,
         repo_verify_origin => true,
-        tarball_max_size => 64 * 1024 * 1024,
+        tarball_max_size => 16 * 1024 * 1024,
         tarball_max_uncompressed_size => 64 * 1024 * 1024
     }.

--- a/src/hex_core.erl
+++ b/src/hex_core.erl
@@ -102,6 +102,6 @@ default_config() ->
         repo_organization => undefined,
         repo_verify => true,
         repo_verify_origin => true,
-        tarball_max_size => 8 * 1024 * 1024,
+        tarball_max_size => 64 * 1024 * 1024,
         tarball_max_uncompressed_size => 64 * 1024 * 1024
     }.


### PR DESCRIPTION
I opted for the 2nd option as per described in the issue as it's the quickest and easiest to resolve my issue and allow me to publish docs again. I'll open a separate issue on `rebar3_hex` to discuss the option of moving to `create_docs/2`. 