### PR TITLE
Match docs tarball error to package error

### DIFF
--- a/src/hex_tarball.erl
+++ b/src/hex_tarball.erl
@@ -101,11 +101,14 @@ create_docs(Files, #{tarball_max_size := TarballMaxSize, tarball_max_uncompresse
     Tarball = gzip(UncompressedTarball),
     Size = byte_size(Tarball),
 
-    case(Size > TarballMaxSize) or (UncompressedSize > TarballMaxUncompressedSize) of
-        true ->
-            {error, {tarball, too_big}};
+    case {(Size > TarballMaxSize), (UncompressedSize > TarballMaxUncompressedSize)} of
+        {_, true} -> 
+            {error, {tarball, {too_big_uncompressed, TarballMaxUncompressedSize}}};
 
-        false ->
+        {true, _} ->
+            {error, {tarball, {too_big_compressed, TarballMaxSize}}};
+
+        {false, false} ->
             {ok, Tarball}
     end.
 

--- a/test/hex_tarball_SUITE.erl
+++ b/test/hex_tarball_SUITE.erl
@@ -265,7 +265,9 @@ unpack_error_handling_test(_Config) ->
 docs_too_big_to_create_test(_Config) ->
     Files = [{"index.html", <<"Docs">>}],
     Config = maps:put(tarball_max_size, 100, hex_core:default_config()),
-    {error, {tarball, too_big}} = hex_tarball:create_docs(Files, Config),
+    {error, {tarball, {too_big_compressed, 100}}} = hex_tarball:create_docs(Files, Config),
+    Config1 = maps:put(tarball_max_uncompressed_size, 100, hex_core:default_config()),
+    {error, {tarball, {too_big_uncompressed, 100}}} = hex_tarball:create_docs(Files, Config1),
 
     ok.
 


### PR DESCRIPTION
This helps the cases where the package size may be fine, but the documentation is too large. Previously, it would report as `too_big`, but that excludes how big the size is and if it was too big compressed or uncompressed.

This changes the `create_docs/2` error to match the `create/2` error reporting the reason for error and the size that was calculated