### PR TITLE
Bump package tarball size limits to 16MiB/128MiB

### DIFF
--- a/src/hex_core.erl
+++ b/src/hex_core.erl
@@ -48,10 +48,10 @@
 %%   requires protobuf messages as of hex_core v0.4.0 (default: `true').
 %%
 %% * `tarball_max_size' - Maximum size of package tarball, defaults to
-%%   `8_388_608' (8 MiB). Set to `infinity' to not enforce the limit.
+%%   `16_777_216' (16 MiB). Set to `infinity' to not enforce the limit.
 %%
 %% * `tarball_max_uncompressed_size' - Maximum size of uncompressed package tarball, defaults to
-%%   `67_108_864' (64 MiB). Set to `infinity' to not enforce the limit.
+%%   `134_217_728' (128 MiB). Set to `infinity' to not enforce the limit.
 %%
 %% * `docs_tarball_max_size' - Maximum size of docs tarball, defaults to
 %%   `16_777_216' (16 MiB). Set to `infinity' to not enforce the limit.
@@ -117,8 +117,8 @@ default_config() ->
         repo_organization => undefined,
         repo_verify => true,
         repo_verify_origin => true,
-        tarball_max_size => 8 * 1024 * 1024,
-        tarball_max_uncompressed_size => 64 * 1024 * 1024,
+        tarball_max_size => 16 * 1024 * 1024,
+        tarball_max_uncompressed_size => 128 * 1024 * 1024,
         docs_tarball_max_size => 16 * 1024 * 1024,
         docs_tarball_max_uncompressed_size => 128 * 1024 * 1024
     }.


### PR DESCRIPTION
Ref: https://github.com/hexpm/hex_core/pull/143#issuecomment-1971052267