### PR TITLE
Fix spec as per current implementation

### DIFF
--- a/src/hex_tarball.erl
+++ b/src/hex_tarball.erl
@@ -141,7 +141,7 @@ create_docs(Files, Config) ->
             {error, {tarball, {too_big_uncompressed, TarballMaxUncompressedSize}}}
     end.
 
--spec create_docs(files()) -> {ok, tarball()}.
+-spec create_docs(files()) -> {ok, tarball()} | {error, term()}.
 create_docs(Files) ->
     create_docs(Files, hex_core:default_config()).
 


### PR DESCRIPTION
This is making `rebar3_hex` fail in Dialyzer analysis.