### PR TITLE
CI housekeeping

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,27 +15,30 @@ jobs:
       matrix:
         pair:
           - erlang: master
-            rebar3: 3.22.1
+            rebar3: 3.23.0
+
+          - erlang: 27
+            rebar3: 3.23.0
 
           - erlang: 26
             rebar3: 3.21.0
 
           - erlang: 25
-            rebar3: 3.18.0
+            rebar3: 3.21.0
 
           - erlang: 24
-            rebar3: 3.18.0
+            rebar3: 3.21.0
 
           - erlang: 23
-            rebar3: 3.18.0
+            rebar3: 3.20.0
 
           - erlang: 22
             rebar3: 3.18.0
 
           - erlang: 21
-            rebar3: 3.15.1
+            rebar3: 3.15.2
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: erlef/setup-beam@v1
         with:


### PR DESCRIPTION
This PR bumps the action/checkout and Rebar3 versions in the GitHub CI workflow file.

I still retain the legacy OTP as I'm not sure this project wants to adhere to https://github.com/erlang/rebar3/pull/2555 of only support the latest three OTP versions?