### PR TITLE
Add inets and ssl to applications

### DIFF
--- a/src/hex_core.app.src
+++ b/src/hex_core.app.src
@@ -2,7 +2,7 @@
     {description, "Reference implementation of Hex specifications"},
     {vsn, "0.10.3"},
     {registered, []},
-    {applications, [kernel, stdlib]},
+    {applications, [kernel, stdlib, inets, ssl]},
     {licenses, ["Apache-2.0"]},
     {include_files, ["CHANGELOG.md"]},
     {links, [


### PR DESCRIPTION
They are needed by the default adapter, hex_http_httpc.

I think the idea not to include them was to make the package as lightweight as possible but in those circumstance people might be vendoring (parts of) it anyway.
