### PR TITLE
Restrict global OAuth tokens to Hex.pm repositories

### DIFF
--- a/src/hex_cli_auth.erl
+++ b/src/hex_cli_auth.erl
@@ -271,7 +271,7 @@ with_repo(BaseConfig, Fun) ->
 %% <li>`repo_key' from `get_auth_config' callback - passthrough</li>
 %% <li>`auth_key' from `get_auth_config' when `trusted' is true and `oauth_exchange' is true - exchange for OAuth token</li>
 %% <li>`auth_key' from `get_auth_config' when `trusted' is true - use directly</li>
-%% <li>Global OAuth token from `get_oauth_tokens' callback</li>
+%% <li>Global OAuth token from `get_oauth_tokens' callback for Hex.pm repositories</li>
 %% <li>No auth when `optional' is true (with retry on 401)</li>
 %% <li>Prompt via `should_authenticate' when `auth_inline' is true</li>
 %% </ol>
@@ -473,7 +473,7 @@ resolve_api_auth(_Permission, Config) ->
 %% 1. repo_key from get_auth_config => passthrough
 %% 2. trusted + auth_key + oauth_exchange => exchange for OAuth token
 %% 3. trusted + auth_key => use directly
-%% 4. trusted + global OAuth tokens => use those
+%% 4. trusted Hex.pm or child repository + global OAuth tokens => use those
 %% 5. Fallthrough to no_auth (handled by with_repo/3 for optional/auth_inline)
 -spec resolve_repo_auth(hex_core:config()) ->
     {ok, binary(), auth_context()} | no_auth | {error, auth_error()}.
@@ -515,8 +515,8 @@ do_resolve_repo_auth(RepoName, LookupRepo, Config) ->
                 [ParentName, _OrgName] ->
                     do_resolve_repo_auth(RepoName, ParentName, Config);
                 _ ->
-                    %% 6. trusted + global OAuth tokens => use those
-                    resolve_global_oauth_for_repo(Config)
+                    %% 6. trusted Hex.pm or child repository + global OAuth tokens => use those
+                    resolve_global_oauth_for_repo(RepoName, Config)
             end;
         _ ->
             %% 7. Not trusted, no auth
@@ -524,6 +524,13 @@ do_resolve_repo_auth(RepoName, LookupRepo, Config) ->
     end.
 
 %% @private
+resolve_global_oauth_for_repo(<<"hexpm">>, Config) ->
+    resolve_global_oauth_for_repo(Config);
+resolve_global_oauth_for_repo(<<"hexpm:", _/binary>>, Config) ->
+    resolve_global_oauth_for_repo(Config);
+resolve_global_oauth_for_repo(_RepoName, _Config) ->
+    no_auth.
+
 resolve_global_oauth_for_repo(Config) ->
     case resolve_oauth_token_with_context(Config) of
         {ok, Token, AuthContext} ->

--- a/test/hex_cli_auth_SUITE.erl
+++ b/test/hex_cli_auth_SUITE.erl
@@ -36,6 +36,8 @@ all() ->
         resolve_repo_auth_trusted_auth_key_test,
         resolve_repo_auth_untrusted_ignores_auth_key_test,
         resolve_repo_auth_oauth_fallback_test,
+        resolve_repo_auth_oauth_fallback_child_repo_test,
+        resolve_repo_auth_oauth_fallback_custom_repo_test,
         resolve_repo_auth_no_auth_test,
 
         %% resolve_repo_auth tests - token exchange
@@ -248,6 +250,35 @@ resolve_repo_auth_oauth_fallback_test(_Config) ->
 
     {ok, RepoKey, _} = hex_cli_auth:resolve_repo_auth(Config#{trusted => true}),
     ?assertEqual(<<"Bearer global_oauth">>, RepoKey),
+    ok.
+
+resolve_repo_auth_oauth_fallback_child_repo_test(_Config) ->
+    Now = erlang:system_time(second),
+    Config = config_with_callbacks(#{
+        auth_config => #{},
+        oauth_tokens =>
+            {ok, #{
+                access_token => <<"global_oauth">>,
+                expires_at => Now + 3600
+            }}
+    }),
+
+    {ok, RepoKey, _} = hex_cli_auth:resolve_repo_auth(
+        Config#{repo_organization => <<"myorg">>, trusted => true}
+    ),
+    ?assertEqual(<<"Bearer global_oauth">>, RepoKey),
+    ok.
+
+resolve_repo_auth_oauth_fallback_custom_repo_test(_Config) ->
+    Config = config_with_callbacks(#{
+        auth_config => #{},
+        get_oauth_tokens => fun() -> error(global_oauth_callback_called) end
+    }),
+
+    Result = hex_cli_auth:resolve_repo_auth(
+        Config#{repo_name => <<"custom">>, trusted => true}
+    ),
+    ?assertEqual(no_auth, Result),
     ok.
 
 resolve_repo_auth_no_auth_test(_Config) ->


### PR DESCRIPTION
Restrict the global OAuth fallback for repository requests to `hexpm` and its child repositories. Custom repositories continue to use their configured repository credentials or downstream authentication such as `.netrc`.

Keep per-repository keys and OAuth exchanges unchanged. Add coverage for Hex.pm child repositories and trusted custom repositories that must not evaluate the global OAuth callback.

Related to hexpm/hex#1216.
