### PR TITLE
Walk the unpacked tree without following symlinks in the mtime pass

### DIFF
--- a/src/hex_tarball.erl
+++ b/src/hex_tarball.erl
@@ -487,10 +487,7 @@ finish_unpack(#{
             filelib:ensure_dir(filename:join(Output, "*")),
             case unpack_contents(Contents, Output, MaxUncompressedSize) of
                 ok ->
-                    [
-                        try_updating_mtime(filename:join(Output, P))
-                     || P <- filelib:wildcard("**", Output)
-                    ],
+                    update_mtimes(Output),
                     copy_metadata_config(Output, maps:get("metadata.config", Files)),
                     {ok, Result};
                 {error, Reason} ->
@@ -1099,10 +1096,7 @@ unpack_tarball(Source, Output, MaxSize) ->
     filelib:ensure_dir(filename:join(Output, "*")),
     case hex_erl_tar:extract(Source, [{cwd, Output}, compressed, {max_size, MaxSize}]) of
         ok ->
-            [
-                try_updating_mtime(filename:join(Output, Path))
-             || Path <- filelib:wildcard("**", Output)
-            ],
+            update_mtimes(Output),
             ok;
         {error, too_big} ->
             {error, {tarball, {too_big_uncompressed, MaxSize}}};
@@ -1111,11 +1105,30 @@ unpack_tarball(Source, Output, MaxSize) ->
     end.
 
 %% @private
-%% let it silently fail for bad symlinks
-try_updating_mtime(Path) ->
-    Time = calendar:universal_time(),
-    _ = file:write_file_info(Path, #file_info{mtime = Time}, [{time, universal}]),
-    ok.
+%% Skips symlinks: write_file_info/3 follows them, and descending into
+%% symlinked directories loops on link cycles. Failures are ignored.
+update_mtimes(Dir) ->
+    update_mtimes(Dir, calendar:universal_time()).
+
+update_mtimes(Dir, Time) ->
+    case file:list_dir(Dir) of
+        {ok, Names} ->
+            lists:foreach(fun(Name) -> update_mtime(filename:join(Dir, Name), Time) end, Names);
+        {error, _} ->
+            ok
+    end.
+
+update_mtime(Path, Time) ->
+    case file:read_link_info(Path, [{time, universal}]) of
+        {ok, #file_info{type = directory}} ->
+            _ = file:write_file_info(Path, #file_info{mtime = Time}, [{time, universal}]),
+            update_mtimes(Path, Time);
+        {ok, #file_info{type = regular}} ->
+            _ = file:write_file_info(Path, #file_info{mtime = Time}, [{time, universal}]),
+            ok;
+        _ ->
+            ok
+    end.
 
 %% @private
 create_memory_tarball(Files) ->

--- a/test/hex_tarball_SUITE.erl
+++ b/test/hex_tarball_SUITE.erl
@@ -12,6 +12,7 @@ all() ->
         timestamps_and_permissions_test,
         symlinks_test,
         symlinks_parent_dir_test,
+        symlink_cycle_test,
         unsafe_paths_to_create_test,
         unsupported_file_types_to_create_test,
         memory_test,
@@ -276,6 +277,34 @@ symlinks_parent_dir_test(Config) ->
     {error, {tarball, {unsafe_symlink, "dir/link.sh", "../../escape"}}} =
         hex_tarball:create(Metadata, UnsafeFiles, CreateConfig),
 
+    ok.
+
+%% dir/loop -> .. resolves inside the extraction dir but forms a cycle, so the
+%% post-unpack mtime pass must not traverse symlinked directories.
+symlink_cycle_test(Config) ->
+    BaseDir = ?config(priv_dir, Config),
+    Metadata = #{<<"name">> => <<"cycle">>, <<"version">> => <<"1.0.0">>},
+
+    Dir = filename:join(BaseDir, "cycle_dir"),
+    ok = file:make_dir(Dir),
+    ok = file:write_file(filename:join(Dir, "foo.sh"), <<"foo">>),
+    ok = file:make_symlink("..", filename:join(Dir, "loop")),
+
+    Files = [
+        {"dir/foo.sh", filename:join("cycle_dir", "foo.sh")},
+        {"dir/loop", filename:join("cycle_dir", "loop")}
+    ],
+    CreateConfig = maps:put(tarball_files_root, BaseDir, hex_core:default_config()),
+
+    {ok, #{tarball := Tarball}} = hex_tarball:create(Metadata, Files, CreateConfig),
+    UnpackDir = filename:join(BaseDir, "symlink_cycle"),
+    {ok, _} = hex_tarball:unpack(Tarball, UnpackDir),
+
+    {ok, #file_info{type = symlink}} =
+        file:read_link_info(filename:join([UnpackDir, "dir", "loop"])),
+    {ok, FooShInfo} = file:read_file_info(filename:join([UnpackDir, "dir", "foo.sh"])),
+    [{{Year, _, _}, _}] = calendar:local_time_to_universal_time_dst(FooShInfo#file_info.mtime),
+    {{Year, _, _}, _} = calendar:local_time(),
     ok.
 
 unsafe_paths_to_create_test(Config) ->


### PR DESCRIPTION
After extracting a tarball to disk, unpack refreshes every file's mtime by listing the tree with `filelib:wildcard("**")` and calling `file:write_file_info/3` on each path. Both follow symlinks: the wildcard descends into symlinked directories and `write_file_info` resolves the link target. Tarballs published by old Hex clients can contain in-tree symlink cycles (`create` rejects them today, unpack still accepts them), and on such a package the pass visits every file once per cycle expansion. [svx 0.2.0](https://hex.pm/packages/svx/0.2.0) ships an example app's `_build` with two such cycles: it holds 1,171 regular files, but the wildcard enumerates ~47k paths (bounded only by the kernel's symlink depth limit), so a 263ms `hex_erl_tar` extraction turns into a 6.4s `unpack` on a fast local disk and 22s on a small cloud instance.

This replaces the wildcard with a `read_link_info` walk that updates regular files and directories, never descends into or touches symlinks, and computes the timestamp once. Both call sites (package unpack and docs unpack) use it. Measured on the same svx tarball, `hex_tarball:unpack` drops from 6,381ms to 326ms locally, and from 22.3s to 332ms on the cloud instance. Skipping symlinks also stops `write_file_info` from writing through them, which previously touched whatever the link resolved to.

Found while debugging hexpm diff-worker timeouts on this package, where the same wildcard pattern existed in hexpm's own tree walk and is fixed separately.