### PR TITLE
Expose organization authentication requirements in OAuth flows

### DIFF
--- a/src/hex_api_oauth.erl
+++ b/src/hex_api_oauth.erl
@@ -8,8 +8,8 @@
     device_auth_flow/5,
     poll_device_token/3,
     refresh_token/3,
-    sso_authorization/2,
-    sso_reauth_required/1,
+    organization_authorization/2,
+    organization_reauth_required/1,
     revoke_token/3,
     client_credentials_token/4,
     client_credentials_token/5,
@@ -22,10 +22,10 @@
     access_token := binary(),
     refresh_token => binary(),
     expires_at := integer(),
-    %% Organizations the session must authenticate against their identity
-    %% provider for. Their scopes are not in this token and re-requesting them
-    %% will not help; see sso_authorization/2.
-    sso_reauth_required => [binary()]
+    %% Organizations whose SSO or 2FA requirements the session must satisfy.
+    %% Their scopes are absent until verification is complete; see
+    %% organization_authorization/2.
+    organization_reauth_required => [map()]
 }.
 
 -type device_auth_error() ::
@@ -205,7 +205,7 @@ poll_for_token_loop(Config, ClientId, DeviceCode, IntervalSeconds, ExpiresAt) ->
                                 expires_at => erlang:system_time(second) + ExpiresIn
                             },
                             {ok,
-                                put_sso_reauth_required(
+                                put_organization_reauth_required(
                                     put_refresh_token(Tokens, TokenResponse), TokenResponse
                                 )};
                         error ->
@@ -293,27 +293,27 @@ refresh_token(Config, ClientId, RefreshToken) ->
     hex_api:post(Config, Path, Params).
 
 %% @doc
-%% Requests a URL for authenticating the current session against organizations
-%% that require single sign-on.
+%% Requests a browser URL to verify the organizations' SSO and 2FA requirements
+%% for the current OAuth session.
 %%
 %% The session the access token belongs to is the one being authorized: its
-%% owner opens the URL in a browser, completes SSO, and the next token refresh
-%% carries the scopes again. The URL is single-use and short-lived.
+%% owner completes the required verification in a browser. The next token
+%% refresh carries the scopes again. The URL is single-use and short-lived.
 %%
 %% Examples:
 %%
 %% ```
 %% 1> Config = hex_core:default_config().
-%% 2> hex_api_oauth:sso_authorization(Config, [<<"acme">>]).
+%% 2> hex_api_oauth:organization_authorization(Config, [<<"acme">>]).
 %% {ok, {201, _, #{
-%%     <<"verification_uri">> => <<"https://hex.pm/sso/authorize/...">>,
+%%     <<"verification_uri">> => <<"https://hex.pm/organizations/authorize?code=...">>,
 %%     <<"expires_in">> => 600
 %% }}}
 %% '''
 %% @end
--spec sso_authorization(hex_core:config(), [binary()]) -> hex_api:response().
-sso_authorization(Config, Organizations) ->
-    Path = <<"oauth/sso_authorization">>,
+-spec organization_authorization(hex_core:config(), [binary()]) -> hex_api:response().
+organization_authorization(Config, Organizations) ->
+    Path = <<"oauth/organization_authorization">>,
     hex_api:post(Config, Path, #{<<"organizations">> => Organizations}).
 
 %% @doc
@@ -398,24 +398,39 @@ revoke_token(Config, ClientId, Token) ->
     hex_api:post(Config, Path, Params).
 
 %% @doc
-%% Organizations a token response says the session has to authenticate against
-%% their identity provider for.
-%%
-%% Returns `{ok, []}' when the response does not carry the field, which is what
-%% servers that predate it send and means nothing is lapsed. Returns `error'
-%% when the field is there in a shape that cannot be read, which says nothing
-%% about what has lapsed and must not be taken for the empty set.
+%% Missing organization authentication requirements in a token response.
+%% An absent field means no outstanding requirements. Malformed fields are
+%% rejected so callers cannot report successful authentication from them.
 %% @end
--spec sso_reauth_required(map()) -> {ok, [binary()]} | error.
-sso_reauth_required(#{<<"sso_reauth_required">> := Organizations}) when is_list(Organizations) ->
-    case lists:all(fun is_binary/1, Organizations) of
-        true -> {ok, Organizations};
-        false -> error
-    end;
-sso_reauth_required(#{<<"sso_reauth_required">> := _Organizations}) ->
+-spec organization_reauth_required(map()) -> {ok, [map()]} | error.
+organization_reauth_required(#{<<"organization_reauth_required">> := Entries}) when
+    is_list(Entries)
+->
+    parse_organization_requirements(Entries, []);
+organization_reauth_required(#{<<"organization_reauth_required">> := _}) ->
     error;
-sso_reauth_required(_TokenResponse) ->
+organization_reauth_required(_) ->
     {ok, []}.
+
+parse_organization_requirements([], Acc) ->
+    {ok, lists:reverse(Acc)};
+parse_organization_requirements(
+    [
+        #{<<"organization">> := Name, <<"requirements">> := Requirements} | Rest
+    ],
+    Acc
+) when is_binary(Name), byte_size(Name) > 0, is_list(Requirements), Requirements =/= [] ->
+    case lists:all(fun(R) -> R =:= <<"tfa">> orelse R =:= <<"sso">> end, Requirements) of
+        true ->
+            parse_organization_requirements(
+                Rest,
+                [#{organization => Name, requirements => lists:usort(Requirements)} | Acc]
+            );
+        false ->
+            error
+    end;
+parse_organization_requirements(_, _) ->
+    error.
 
 %%====================================================================
 %% Internal functions
@@ -514,11 +529,11 @@ put_refresh_token(Tokens, _TokenResponse) ->
     Tokens.
 
 %% @private
-%% A response whose sso_reauth_required cannot be read carries no key, so the
+%% A response whose organization_reauth_required cannot be read carries no key, so the
 %% caller is not handed the empty set as if the server had sent it.
-put_sso_reauth_required(Tokens, TokenResponse) ->
-    case sso_reauth_required(TokenResponse) of
-        {ok, Organizations} -> Tokens#{sso_reauth_required => Organizations};
+put_organization_reauth_required(Tokens, TokenResponse) ->
+    case organization_reauth_required(TokenResponse) of
+        {ok, Organizations} -> Tokens#{organization_reauth_required => Organizations};
         error -> Tokens
     end.
 

--- a/src/hex_cli_auth.erl
+++ b/src/hex_cli_auth.erl
@@ -36,12 +36,12 @@
 %%     clear_oauth_tokens => fun(() -> ok),
 %%
 %%     %% Report the organizations the server says this session has to
-%%     %% authenticate against their identity provider for (optional). Called
+%%     %% complete SSO or 2FA verification for (optional). Called
 %%     %% after every token grant that carried a readable set, with the empty
 %%     %% list when there are none, so the build tool always holds the current
 %%     %% set. It is not told which of them the running command needs; deciding
 %%     %% that is the build tool's job.
-%%     sso_reauth => fun(([binary()]) -> ok),
+%%     organization_reauth => fun(([map()]) -> ok),
 %%
 %%     %% User interaction
 %%     prompt_otp => fun((Message :: binary()) -> {ok, OtpCode :: binary()} | cancelled),
@@ -139,7 +139,7 @@
         ) -> ok
     ),
     clear_oauth_tokens => fun(() -> ok),
-    sso_reauth => fun((Organizations :: [binary()]) -> ok),
+    organization_reauth => fun((Organizations :: [map()]) -> ok),
     prompt_otp := fun((Message :: binary()) -> {ok, OtpCode :: binary()} | cancelled),
     should_authenticate := fun((Reason :: auth_prompt_reason()) -> boolean()),
     get_client_id := fun(() -> binary())
@@ -515,7 +515,7 @@ renew_repo_auth_and_retry(BaseConfig, Fun, RepoKey, Response) ->
 %% Refreshes the stored global OAuth token now, whether or not it has expired.
 %%
 %% What a token carries can change without it expiring: authenticating a
-%% session against an organization's identity provider grants scopes the
+%% session for an organization's authentication requirements grants scopes the
 %% current access token was minted without. This is how a build tool picks
 %% those up rather than waiting out the access token.
 -spec refresh_tokens(hex_core:config()) -> ok | {error, auth_error()}.
@@ -559,12 +559,12 @@ device_auth(Config, Scope, Opts) ->
     FlowOpts = [{open_browser, OpenBrowser}],
     case hex_api_oauth:device_auth_flow(Config, ClientId, Scope, PromptUser, FlowOpts) of
         {ok, Response} ->
-            %% sso_reauth_required reaches the build tool through the sso_reauth
+            %% organization_reauth_required reaches the build tool through the organization_reauth
             %% callback rather than with the tokens. The response carries no key
             %% when the server sent a set that could not be read.
-            Tokens = maps:without([sso_reauth_required], Response),
+            Tokens = maps:without([organization_reauth_required], Response),
             ok = persist_tokens(Config, global, Tokens),
-            report_sso_reauth(Config, maps:find(sso_reauth_required, Response)),
+            report_organization_reauth(Config, maps:find(organization_reauth_required, Response)),
             {ok, Tokens};
         {error, timeout} ->
             {error, {auth_error, device_auth_timeout}};
@@ -820,7 +820,9 @@ maybe_refresh_token_with_context(Config, #{refresh_token := RefreshToken}) when
                 expires_at => erlang:system_time(second) + ExpiresIn
             },
             ok = persist_tokens(Config, global, NewTokens),
-            report_sso_reauth(Config, hex_api_oauth:sso_reauth_required(TokenResponse)),
+            report_organization_reauth(
+                Config, hex_api_oauth:organization_reauth_required(TokenResponse)
+            ),
             BearerToken = <<"Bearer ", NewAccessToken/binary>>,
             {ok, BearerToken, #{has_refresh_token => has_refresh_token(NewTokens)}};
         {ok, {Status, _, _Body}} when Status =:= 400; Status =:= 401 ->
@@ -1001,9 +1003,9 @@ call_callback(Config, Name, Args) ->
 %% resolved does not linger. A grant whose set could not be read is not
 %% reported: the empty list would be taken for the server saying there is
 %% nothing, and the build tool would drop the organizations it holds.
-report_sso_reauth(Config, {ok, Organizations}) when is_list(Organizations) ->
-    maybe_call_callback(Config, sso_reauth, [Organizations]);
-report_sso_reauth(_Config, error) ->
+report_organization_reauth(Config, {ok, Organizations}) when is_list(Organizations) ->
+    maybe_call_callback(Config, organization_reauth, [Organizations]);
+report_organization_reauth(_Config, error) ->
     ok.
 
 %% @private

--- a/test/hex_api_SUITE.erl
+++ b/test/hex_api_SUITE.erl
@@ -38,10 +38,10 @@ all() ->
         oauth_device_auth_flow_malformed_device_response_test,
         oauth_device_auth_flow_malformed_token_response_test,
         oauth_refresh_token_test,
-        oauth_sso_authorization_test,
-        oauth_device_auth_flow_sso_reauth_test,
-        oauth_device_auth_flow_malformed_sso_reauth_test,
-        oauth_sso_reauth_required_test,
+        oauth_organization_authorization_test,
+        oauth_device_auth_flow_organization_reauth_test,
+        oauth_device_auth_flow_malformed_organization_reauth_test,
+        oauth_organization_reauth_required_test,
         oauth_win_cmd_args_escapes_metacharacters_test,
         oauth_revoke_test,
         oauth_client_credentials_test,
@@ -409,17 +409,17 @@ oauth_refresh_token_test(_Config) ->
     ?assert(is_integer(ExpiresIn)),
     ok.
 
-oauth_sso_authorization_test(_Config) ->
-    {ok, {201, _, Response}} = hex_api_oauth:sso_authorization(?CONFIG, [<<"acme">>]),
+oauth_organization_authorization_test(_Config) ->
+    {ok, {201, _, Response}} = hex_api_oauth:organization_authorization(?CONFIG, [<<"acme">>]),
     #{
         <<"verification_uri">> := VerificationUri,
         <<"expires_in">> := ExpiresIn
     } = Response,
-    ?assertEqual(<<"https://hex.pm/sso/authorize/acme">>, VerificationUri),
+    ?assertEqual(<<"https://hex.pm/organizations/authorize/acme">>, VerificationUri),
     ?assert(is_integer(ExpiresIn)),
     ok.
 
-oauth_device_auth_flow_sso_reauth_test(_Config) ->
+oauth_device_auth_flow_organization_reauth_test(_Config) ->
     % The organizations a token was minted without reach the caller
     ClientId = <<"cli">>,
     Scope = <<"repositories">>,
@@ -431,7 +431,9 @@ oauth_device_auth_flow_sso_reauth_test(_Config) ->
         <<"refresh_token">> => <<"test_refresh_token">>,
         <<"token_type">> => <<"Bearer">>,
         <<"expires_in">> => 3600,
-        <<"sso_reauth_required">> => [<<"acme">>]
+        <<"organization_reauth_required">> => [
+            #{<<"organization">> => <<"acme">>, <<"requirements">> => [<<"sso">>]}
+        ]
     },
     Headers = #{<<"content-type">> => <<"application/vnd.hex+erlang; charset=utf-8">>},
     Self !
@@ -440,10 +442,13 @@ oauth_device_auth_flow_sso_reauth_test(_Config) ->
 
     {ok, Tokens} = hex_api_oauth:device_auth_flow(?CONFIG, ClientId, Scope, PromptUser),
 
-    ?assertEqual([<<"acme">>], maps:get(sso_reauth_required, Tokens)),
+    ?assertEqual(
+        [#{organization => <<"acme">>, requirements => [<<"sso">>]}],
+        maps:get(organization_reauth_required, Tokens)
+    ),
     ok.
 
-oauth_device_auth_flow_malformed_sso_reauth_test(_Config) ->
+oauth_device_auth_flow_malformed_organization_reauth_test(_Config) ->
     % A set the server sent in a shape we cannot read carries no key at all. The
     % empty list means "nothing lapsed", which is not what the response said.
     ClientId = <<"cli">>,
@@ -456,7 +461,7 @@ oauth_device_auth_flow_malformed_sso_reauth_test(_Config) ->
         <<"refresh_token">> => <<"test_refresh_token">>,
         <<"token_type">> => <<"Bearer">>,
         <<"expires_in">> => 3600,
-        <<"sso_reauth_required">> => <<"acme">>
+        <<"organization_reauth_required">> => <<"acme">>
     },
     Headers = #{<<"content-type">> => <<"application/vnd.hex+erlang; charset=utf-8">>},
     Self !
@@ -465,33 +470,65 @@ oauth_device_auth_flow_malformed_sso_reauth_test(_Config) ->
 
     {ok, Tokens} = hex_api_oauth:device_auth_flow(?CONFIG, ClientId, Scope, PromptUser),
 
-    ?assertNot(maps:is_key(sso_reauth_required, Tokens)),
+    ?assertNot(maps:is_key(organization_reauth_required, Tokens)),
     ok.
 
-oauth_sso_reauth_required_test(_Config) ->
+oauth_organization_reauth_required_test(_Config) ->
+    ?assertEqual(
+        {ok, [#{organization => <<"acme">>, requirements => [<<"sso">>, <<"tfa">>]}]},
+        hex_api_oauth:organization_reauth_required(#{
+            <<"organization_reauth_required">> => [
+                #{<<"organization">> => <<"acme">>, <<"requirements">> => [<<"tfa">>, <<"sso">>]}
+            ]
+        })
+    ),
+    lists:foreach(
+        fun(Entry) ->
+            ?assertEqual(
+                error,
+                hex_api_oauth:organization_reauth_required(
+                    #{<<"organization_reauth_required">> => [Entry]}
+                )
+            )
+        end,
+        [
+            #{<<"organization">> => <<"acme">>},
+            #{<<"organization">> => <<"acme">>, <<"requirements">> => []},
+            #{<<"organization">> => <<"acme">>, <<"requirements">> => [<<"password">>]},
+            #{<<"organization">> => <<>>, <<"requirements">> => [<<"tfa">>]}
+        ]
+    ),
     % A response that does not carry the field is a server that predates it and
     % means nothing is lapsed; one that carries an unreadable value means the
     % response says nothing at all.
-    ?assertEqual({ok, []}, hex_api_oauth:sso_reauth_required(#{})),
+    ?assertEqual({ok, []}, hex_api_oauth:organization_reauth_required(#{})),
     ?assertEqual(
         {ok, []},
-        hex_api_oauth:sso_reauth_required(#{<<"sso_reauth_required">> => []})
+        hex_api_oauth:organization_reauth_required(#{<<"organization_reauth_required">> => []})
     ),
     ?assertEqual(
-        {ok, [<<"acme">>]},
-        hex_api_oauth:sso_reauth_required(#{<<"sso_reauth_required">> => [<<"acme">>]})
-    ),
-    ?assertEqual(
-        error,
-        hex_api_oauth:sso_reauth_required(#{<<"sso_reauth_required">> => <<"acme">>})
-    ),
-    ?assertEqual(
-        error,
-        hex_api_oauth:sso_reauth_required(#{<<"sso_reauth_required">> => [<<"acme">>, 42]})
+        {ok, [#{organization => <<"acme">>, requirements => [<<"sso">>]}]},
+        hex_api_oauth:organization_reauth_required(#{
+            <<"organization_reauth_required">> => [
+                #{<<"organization">> => <<"acme">>, <<"requirements">> => [<<"sso">>]}
+            ]
+        })
     ),
     ?assertEqual(
         error,
-        hex_api_oauth:sso_reauth_required(#{<<"sso_reauth_required">> => null})
+        hex_api_oauth:organization_reauth_required(#{
+            <<"organization_reauth_required">> => <<"acme">>
+        })
+    ),
+    ?assertEqual(
+        error,
+        hex_api_oauth:organization_reauth_required(#{
+            <<"organization_reauth_required">> => [<<"acme">>, 42]
+        })
+    ),
+    ?assertEqual(
+        error,
+        hex_api_oauth:organization_reauth_required(#{<<"organization_reauth_required">> => null})
     ),
     ok.
 

--- a/test/hex_cli_auth_SUITE.erl
+++ b/test/hex_cli_auth_SUITE.erl
@@ -52,10 +52,10 @@ all() ->
         with_api_otp_cancelled_test,
         with_api_otp_max_retries_test,
 
-        %% sso re-authorization
-        sso_reauth_reported_on_refresh_test,
-        sso_reauth_reported_empty_test,
-        sso_reauth_malformed_not_reported_test,
+        %% organization re-authorization
+        organization_reauth_reported_on_refresh_test,
+        organization_reauth_reported_empty_test,
+        organization_reauth_malformed_not_reported_test,
         refresh_tokens_forces_a_refresh_test,
         refresh_tokens_without_credentials_test,
 
@@ -1647,7 +1647,7 @@ device_auth_lock_released_before_request_test(_Config) ->
 %% Helper Functions
 %%====================================================================
 
-sso_reauth_reported_on_refresh_test(_Config) ->
+organization_reauth_reported_on_refresh_test(_Config) ->
     %% The organizations the server flags on a refresh reach the build tool.
     Now = erlang:system_time(second),
     Self = self(),
@@ -1658,24 +1658,31 @@ sso_reauth_reported_on_refresh_test(_Config) ->
                 refresh_token => <<"refresh_token">>,
                 expires_at => Now - 100
             }},
-        sso_reauth => fun(Organizations) ->
-            Self ! {sso_reauth, Organizations},
+        organization_reauth => fun(Organizations) ->
+            Self ! {organization_reauth, Organizations},
             ok
         end
     }),
 
-    queue_refresh_response(#{<<"sso_reauth_required">> => [<<"acme">>]}),
+    queue_refresh_response(#{
+        <<"organization_reauth_required">> => [
+            #{<<"organization">> => <<"acme">>, <<"requirements">> => [<<"sso">>]}
+        ]
+    }),
 
     {ok, _ApiKey, _AuthContext} = hex_cli_auth:resolve_api_auth(read, Config),
 
     receive
-        {sso_reauth, Organizations} -> ?assertEqual([<<"acme">>], Organizations)
+        {organization_reauth, Organizations} ->
+            ?assertEqual(
+                [#{organization => <<"acme">>, requirements => [<<"sso">>]}], Organizations
+            )
     after 100 ->
-        error(sso_reauth_not_called)
+        error(organization_reauth_not_called)
     end,
     ok.
 
-sso_reauth_reported_empty_test(_Config) ->
+organization_reauth_reported_empty_test(_Config) ->
     %% A server that says nothing means nothing is lapsed, and the build tool
     %% is told so rather than left holding a stale set.
     Now = erlang:system_time(second),
@@ -1687,8 +1694,8 @@ sso_reauth_reported_empty_test(_Config) ->
                 refresh_token => <<"refresh_token">>,
                 expires_at => Now - 100
             }},
-        sso_reauth => fun(Organizations) ->
-            Self ! {sso_reauth, Organizations},
+        organization_reauth => fun(Organizations) ->
+            Self ! {organization_reauth, Organizations},
             ok
         end
     }),
@@ -1696,13 +1703,13 @@ sso_reauth_reported_empty_test(_Config) ->
     {ok, _ApiKey, _AuthContext} = hex_cli_auth:resolve_api_auth(read, Config),
 
     receive
-        {sso_reauth, Organizations} -> ?assertEqual([], Organizations)
+        {organization_reauth, Organizations} -> ?assertEqual([], Organizations)
     after 100 ->
-        error(sso_reauth_not_called)
+        error(organization_reauth_not_called)
     end,
     ok.
 
-sso_reauth_malformed_not_reported_test(_Config) ->
+organization_reauth_malformed_not_reported_test(_Config) ->
     %% A set the server sent in a shape we cannot read is not reported at all.
     %% The build tool takes the empty list for "nothing lapsed" and deletes the
     %% organizations it holds, which drops the prompt the user needs.
@@ -1715,18 +1722,18 @@ sso_reauth_malformed_not_reported_test(_Config) ->
                 refresh_token => <<"refresh_token">>,
                 expires_at => Now - 100
             }},
-        sso_reauth => fun(Organizations) ->
-            Self ! {sso_reauth, Organizations},
+        organization_reauth => fun(Organizations) ->
+            Self ! {organization_reauth, Organizations},
             ok
         end
     }),
 
-    queue_refresh_response(#{<<"sso_reauth_required">> => <<"acme">>}),
+    queue_refresh_response(#{<<"organization_reauth_required">> => <<"acme">>}),
 
     {ok, _ApiKey, _AuthContext} = hex_cli_auth:resolve_api_auth(read, Config),
 
     receive
-        {sso_reauth, Organizations} -> error({sso_reauth_reported, Organizations})
+        {organization_reauth, Organizations} -> error({organization_reauth_reported, Organizations})
     after 0 -> ok
     end,
     ok.
@@ -1857,7 +1864,7 @@ make_callbacks(Opts) ->
     ShouldAuthenticate = maps:get(should_authenticate, Opts, fun(_) -> false end),
     PersistFn = maps:get(persist_oauth_tokens, Opts, fun(_, _, _, _) -> ok end),
     ClearFn = maps:get(clear_oauth_tokens, Opts, fun() -> ok end),
-    SsoReauthFn = maps:get(sso_reauth, Opts, fun(_Organizations) -> ok end),
+    OrganizationReauthFn = maps:get(organization_reauth, Opts, fun(_Organizations) -> ok end),
     DefaultGetOAuthTokens = fun() -> maps:get(oauth_tokens, Opts, error) end,
     GetOAuthTokensFn = maps:get(get_oauth_tokens, Opts, DefaultGetOAuthTokens),
 
@@ -1866,7 +1873,7 @@ make_callbacks(Opts) ->
         get_oauth_tokens => GetOAuthTokensFn,
         persist_oauth_tokens => PersistFn,
         clear_oauth_tokens => ClearFn,
-        sso_reauth => SsoReauthFn,
+        organization_reauth => OrganizationReauthFn,
         prompt_otp => PromptOtp,
         should_authenticate => ShouldAuthenticate,
         get_client_id => fun() -> <<"test_client">> end

--- a/test/support/hex_http_test.erl
+++ b/test/support/hex_http_test.erl
@@ -428,11 +428,11 @@ fixture(post, <<?TEST_API_URL, "/oauth/token">>, _, {_, Body}) ->
             {ok, {400, api_headers(), term_to_binary(ErrorPayload)}}
     end;
 
-fixture(post, <<?TEST_API_URL, "/oauth/sso_authorization">>, _, {_, Body}) ->
+fixture(post, <<?TEST_API_URL, "/oauth/organization_authorization">>, _, {_, Body}) ->
     #{<<"organizations">> := Organizations} = binary_to_term(Body),
     Joined = iolist_to_binary(lists:join(<<"-">>, Organizations)),
     Payload = #{
-        <<"verification_uri">> => <<"https://hex.pm/sso/authorize/", Joined/binary>>,
+        <<"verification_uri">> => <<"https://hex.pm/organizations/authorize/", Joined/binary>>,
         <<"expires_in">> => 600
     },
     {ok, {201, api_headers(), term_to_binary(Payload)}};


### PR DESCRIPTION
OAuth grants now preserve the missing authentication requirements for each organization, including independent SSO and 2FA reasons. Add the shared organization authorization endpoint and pass structured requirements through CLI authentication callbacks so clients can request the required browser verification.

Malformed requirement entries retain the previous authentication state instead of clearing it. Validated with 165 Common Test cases, both properties with 100 generated cases each, and the formatter.

Related: https://github.com/hexpm/hexpm/pull/1913, https://github.com/hexpm/hex/pull/1237.
